### PR TITLE
Add method to start app installation

### DIFF
--- a/GooglePlayInstant/Android.cs
+++ b/GooglePlayInstant/Android.cs
@@ -43,7 +43,7 @@ namespace GooglePlayInstant
 
         public const string PackageManagerMethodResolveActivity = "resolveActivity";
 
-        public const string UriBuilderClass = "android.net.Uri.Builder";
+        public const string UriBuilderClass = "android.net.Uri$Builder";
         public const string UriBuilderMethodAppendQueryParameter = "appendQueryParameter";
         public const string UriBuilderMethodAuthority = "authority";
         public const string UriBuilderMethodBuild = "build";

--- a/GooglePlayInstant/Android.cs
+++ b/GooglePlayInstant/Android.cs
@@ -1,0 +1,52 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace GooglePlayInstant
+{
+    /// <summary>
+    /// Android API constants. Also includes some Java class, method, and field names for use by
+    /// <see href="https://docs.unity3d.com/ScriptReference/AndroidJavaObject.html">AndroidJavaObject</see>.
+    /// </summary>
+    public static class Android
+    {
+        public const string PlayStorePackageName = "com.android.vending";
+
+        public const string ActivityMethodGetIntent = "getIntent";
+        public const string ActivityMethodStartActivityForResult = "startActivityForResult";
+
+        public const string ContextMethodGetPackageManager = "getPackageManager";
+
+        public const string IntentActionMain = "android.intent.action.MAIN";
+        public const string IntentActionView = "android.intent.action.VIEW";
+        public const string IntentCategoryBrowsable = "android.intent.category.BROWSABLE";
+        public const string IntentCategoryDefault = "android.intent.category.DEFAULT";
+        public const string IntentCategoryLauncher = "android.intent.category.LAUNCHER";
+        public const string IntentClass = "android.content.Intent";
+        public const string IntentMethodAddCategory = "addCategory";
+        public const string IntentMethodGetStringExtra = "getStringExtra";
+        public const string IntentMethodPutExtra = "putExtra";
+        public const string IntentMethodSetData = "setData";
+        public const string IntentMethodSetPackage = "setPackage";
+
+        public const string ObjectMethodGetClass = "getClass";
+
+        public const string PackageManagerMethodResolveActivity = "resolveActivity";
+
+        public const string UriBuilderClass = "android.net.Uri.Builder";
+        public const string UriBuilderMethodAppendQueryParameter = "appendQueryParameter";
+        public const string UriBuilderMethodAuthority = "authority";
+        public const string UriBuilderMethodBuild = "build";
+        public const string UriBuilderMethodScheme = "scheme";
+    }
+}

--- a/GooglePlayInstant/Editor/AndroidManifest/AndroidManifestHelper.cs
+++ b/GooglePlayInstant/Editor/AndroidManifest/AndroidManifestHelper.cs
@@ -25,14 +25,9 @@ namespace GooglePlayInstant.Editor.AndroidManifest
     public static class AndroidManifestHelper
     {
         private const string Action = "action";
-        private const string ActionMain = "android.intent.action.MAIN";
-        private const string ActionView = "android.intent.action.VIEW";
         private const string Activity = "activity";
         private const string Application = "application";
         private const string Category = "category";
-        private const string CategoryBrowsable = "android.intent.category.BROWSABLE";
-        private const string CategoryDefault = "android.intent.category.DEFAULT";
-        private const string CategoryLauncher = "android.intent.category.LAUNCHER";
         private const string Data = "data";
         private const string DefaultUrl = "default-url";
         private const string IntentFilter = "intent-filter";
@@ -40,6 +35,7 @@ namespace GooglePlayInstant.Editor.AndroidManifest
         private const string MetaData = "meta-data";
         private const string AndroidNamespaceAlias = "android";
         private const string AndroidNamespaceUrl = "http://schemas.android.com/apk/res/android";
+
         private static readonly XName AndroidXmlns = XNamespace.Xmlns + AndroidNamespaceAlias;
         private static readonly XName AndroidAutoVerifyXName = XName.Get("autoVerify", AndroidNamespaceUrl);
         private static readonly XName AndroidHostXName = XName.Get("host", AndroidNamespaceUrl);
@@ -70,8 +66,9 @@ namespace GooglePlayInstant.Editor.AndroidManifest
                     new XElement(Activity,
                         new XAttribute(AndroidNameXName, "com.unity3d.player.UnityPlayerActivity"),
                         new XElement(IntentFilter,
-                            new XElement(Action, new XAttribute(AndroidNameXName, ActionMain)),
-                            new XElement(Category, new XAttribute(AndroidNameXName, CategoryLauncher)))))));
+                            new XElement(Action, new XAttribute(AndroidNameXName, Android.IntentActionMain)),
+                            new XElement(Category, new XAttribute(AndroidNameXName, Android.IntentCategoryLauncher))
+                        )))));
         }
 
         /// <summary>
@@ -171,10 +168,11 @@ namespace GooglePlayInstant.Editor.AndroidManifest
             // See https://developer.android.com/topic/google-play-instant/getting-started/game-instant-app#app-links
             // and https://developer.android.com/training/app-links/verify-site-associations for info on "autoVerify".
             viewIntentFilter.SetAttributeValue(AndroidAutoVerifyXName, "true");
-            viewIntentFilter.Add(CreateElementWithAttribute(Action, AndroidNameXName, ActionView));
+            viewIntentFilter.Add(CreateElementWithAttribute(Action, AndroidNameXName, Android.IntentActionView));
             viewIntentFilter.Add(
-                CreateElementWithAttribute(Category, AndroidNameXName, CategoryBrowsable));
-            viewIntentFilter.Add(CreateElementWithAttribute(Category, AndroidNameXName, CategoryDefault));
+                CreateElementWithAttribute(Category, AndroidNameXName, Android.IntentCategoryBrowsable));
+            viewIntentFilter.Add(CreateElementWithAttribute(Category, AndroidNameXName,
+                Android.IntentCategoryDefault));
             viewIntentFilter.Add(CreateElementWithAttribute(Data, AndroidSchemeXName, "http"));
             viewIntentFilter.Add(CreateElementWithAttribute(Data, AndroidSchemeXName, "https"));
             viewIntentFilter.Add(CreateElementWithAttribute(Data, AndroidHostXName, uri.Host));
@@ -223,9 +221,9 @@ namespace GooglePlayInstant.Editor.AndroidManifest
                     (from intentFilter in activityElement.Elements(IntentFilter)
                         where
                             intentFilter.Elements(Action)
-                                .Any(e => (string) e.Attribute(AndroidNameXName) == ActionMain) &&
+                                .Any(e => (string) e.Attribute(AndroidNameXName) == Android.IntentActionMain) &&
                             intentFilter.Elements(Category)
-                                .Any(e => (string) e.Attribute(AndroidNameXName) == CategoryLauncher)
+                                .Any(e => (string) e.Attribute(AndroidNameXName) == Android.IntentCategoryLauncher)
                         select intentFilter)
                     .Any()
                 select activityElement;
@@ -235,7 +233,8 @@ namespace GooglePlayInstant.Editor.AndroidManifest
         {
             // Find all intent filters that contain <action android:name="android.intent.action.VIEW" />
             return from intentFilter in mainActivity.Elements(IntentFilter)
-                where intentFilter.Elements(Action).Any(e => (string) e.Attribute(AndroidNameXName) == ActionView)
+                where intentFilter.Elements(Action)
+                    .Any(e => (string) e.Attribute(AndroidNameXName) == Android.IntentActionView)
                 select intentFilter;
         }
 

--- a/GooglePlayInstant/InstallLauncher.cs
+++ b/GooglePlayInstant/InstallLauncher.cs
@@ -1,0 +1,193 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using UnityEngine;
+
+namespace GooglePlayInstant
+{
+    /// <summary>
+    /// Provides methods that an instant app can use to display a Play Store install dialog. This dialog will allow
+    /// the user to install the current instant app as a full app. This is an alternative to the Java-based
+    /// <a href="https://developer.android.com/topic/google-play-instant/reference">Google Play Instant API</a>.
+    /// </summary>
+    public static class InstallLauncher
+    {
+        private const string IntentActionInstantAppInstall = "com.google.android.finsky.action.IA_INSTALL";
+        private const int IgnoredRequestCode = 1001;
+
+        /// <summary>
+        /// Shows a dialog that allows the user to install the current instant app.
+        /// </summary>
+        public static void ShowInstallPrompt()
+        {
+            using (var activity = GetCurrentActivity())
+            using (var postInstallIntent = CreatePostInstallIntent(activity))
+            {
+                ShowInstallPrompt(activity, IgnoredRequestCode, postInstallIntent, null);
+            }
+        }
+
+        /// <summary>
+        /// Shows a dialog that allows the user to install the current instant app. This method is a no-op
+        /// if the current running process is an installed app. A post-install intent must be provided,
+        /// which will be used to start the application after install is complete.
+        /// </summary>
+        /// <param name="activity">The activity that should launch the store's install dialog.</param>
+        /// <param name="requestCode">The requestCode referenced in the onActivityResult() callback to the activity.
+        ///     <a href="https://docs.unity3d.com/Manual/AndroidUnityPlayerActivity.html">Extend UnityPlayerActivity</a>
+        ///     and check for the specified requestCode integer to know whether the dialog was cancelled. Use
+        ///     UnityPlayer.UnitySendMessage() to relay the response from Java back to Unity scripts.</param>
+        /// <param name="postInstallIntent">The intent to launch after the instant app has been installed.
+        ///     Must resolve to an activity in the installed app package, or it will not be used.</param>
+        /// <param name="referrer">Optional install referrer string.</param>
+        /// <exception cref="ArgumentNullException">If either activity or postInstallIntent are null.</exception>
+        public static void ShowInstallPrompt(
+            AndroidJavaObject activity, int requestCode, AndroidJavaObject postInstallIntent, string referrer)
+        {
+#if !PLAY_INSTANT
+            return;
+#endif
+
+            if (activity == null)
+            {
+                throw new ArgumentNullException("activity");
+            }
+
+            if (postInstallIntent == null)
+            {
+                throw new ArgumentNullException("postInstallIntent");
+            }
+
+            using (var uri = CreateMarketDetailsUri(referrer))
+            using (var installIntent = new AndroidJavaObject(Android.IntentClass, IntentActionInstantAppInstall))
+            using (installIntent.Call<AndroidJavaObject>(Android.IntentMethodSetData, uri))
+            using (installIntent.Call<AndroidJavaObject>(
+                Android.IntentMethodSetPackage, Android.PlayStorePackageName))
+            using (installIntent.Call<AndroidJavaObject>(
+                Android.IntentMethodPutExtra, "postInstallIntent", postInstallIntent))
+            {
+                if (IsLegacyPlayStore(activity, installIntent))
+                {
+                    ShowLegacyInstallPrompt(activity, requestCode, uri);
+                }
+                else
+                {
+                    activity.Call(Android.ActivityMethodStartActivityForResult, installIntent, requestCode);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the current activity running in Unity.
+        /// This object should be disposed after use.
+        /// </summary>
+        /// <returns>A wrapped activity object. The AndroidJavaObject should be disposed.</returns>
+        public static AndroidJavaObject GetCurrentActivity()
+        {
+            using (var unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer"))
+            {
+                return unityPlayer.GetStatic<AndroidJavaObject>("currentActivity");
+            }
+        }
+
+        /// <summary>
+        /// Creates an Intent for the Play Store to launch after installing the app. It will launch the specified
+        /// activity. This Intent can be extended to contain additional extras for passing to the installed app.
+        /// This object should be disposed after use.
+        /// </summary>
+        /// <returns>A wrapped Intent object. The AndroidJavaObject should be disposed.</returns>
+        public static AndroidJavaObject CreatePostInstallIntent(AndroidJavaObject activity)
+        {
+            using (var activityClass = activity.Call<AndroidJavaObject>(Android.ObjectMethodGetClass))
+            {
+                return new AndroidJavaObject(Android.IntentClass, activity, activityClass);
+            }
+        }
+
+        /// <summary>
+        /// This method can be called with the Intent obtained from <see cref="CreatePostInstallIntent"/>
+        /// to add a string extra that will be passed through to the installed app.
+        /// </summary>
+        /// <param name="postInstallIntent">An Intent obtained from <see cref="CreatePostInstallIntent"/>.</param>
+        /// <param name="extraKey">Key for a string extra to add to the post install intent.</param>
+        /// <param name="extraValue">Value for a string extra to add to the post install intent.</param>
+        public static void PutPostInstallIntentStringExtra(
+            AndroidJavaObject postInstallIntent, string extraKey, string extraValue)
+        {
+            using (postInstallIntent.Call<AndroidJavaObject>(Android.IntentMethodPutExtra, extraKey, extraValue))
+            {
+            }
+        }
+
+        /// <summary>
+        /// This method can be called from an installed app to obtain a string that was included in
+        /// the postInstallIntent provided by an instant app via <see cref="showInstallPrompt"/>.
+        /// It assumes that the current activity was the one that was launched by Play Store.
+        /// </summary>
+        /// <param name="extraKey">Key for obtaining a string extra from current activity's intent.</param>
+        /// <returns>The string extra value.</returns>
+        public static string GetPostInstallIntentStringExtra(string extraKey)
+        {
+            using (var currentActivity = GetCurrentActivity())
+            using (var intent = currentActivity.Call<AndroidJavaObject>(Android.ActivityMethodGetIntent))
+            {
+                return intent.Call<string>(Android.IntentMethodGetStringExtra, extraKey);
+            }
+        }
+
+        private static AndroidJavaObject CreateMarketDetailsUri(string referrer)
+        {
+            using (var uriBuilder = new AndroidJavaObject(Android.UriBuilderClass))
+            using (uriBuilder.Call<AndroidJavaObject>(Android.UriBuilderMethodScheme, "market"))
+            using (uriBuilder.Call<AndroidJavaObject>(Android.UriBuilderMethodAuthority, "details"))
+            using (uriBuilder.Call<AndroidJavaObject>(
+                Android.UriBuilderMethodAppendQueryParameter, "id", Application.identifier))
+            {
+                if (!string.IsNullOrEmpty(referrer))
+                {
+                    using (uriBuilder.Call<AndroidJavaObject>(
+                        Android.UriBuilderMethodAppendQueryParameter, "referrer", referrer))
+                    {
+                    }
+                }
+
+                return uriBuilder.Call<AndroidJavaObject>(Android.UriBuilderMethodBuild);
+            }
+        }
+
+        private static bool IsLegacyPlayStore(AndroidJavaObject context, AndroidJavaObject installIntent)
+        {
+            using (var packageManager = context.Call<AndroidJavaObject>(Android.ContextMethodGetPackageManager))
+            using (var resolveInfo =
+                packageManager.Call<AndroidJavaObject>(Android.PackageManagerMethodResolveActivity, installIntent, 0))
+            {
+                return resolveInfo == null;
+            }
+        }
+
+        private static void ShowLegacyInstallPrompt(AndroidJavaObject activity, int requestCode, AndroidJavaObject uri)
+        {
+            using (var intent = new AndroidJavaObject(Android.IntentClass, Android.IntentActionView))
+            using (intent.Call<AndroidJavaObject>(Android.IntentMethodAddCategory, Android.IntentCategoryDefault))
+            using (intent.Call<AndroidJavaObject>(Android.IntentMethodSetPackage, Android.PlayStorePackageName))
+            using (intent.Call<AndroidJavaObject>(Android.IntentMethodSetData, uri))
+            using (intent.Call<AndroidJavaObject>(Android.IntentMethodPutExtra, "callerId", Application.identifier))
+            using (intent.Call<AndroidJavaObject>(Android.IntentMethodPutExtra, "overlay", true))
+            {
+                activity.Call(Android.ActivityMethodStartActivityForResult, intent, requestCode);
+            }
+        }
+    }
+}

--- a/GooglePlayInstant/InstallLauncher.cs
+++ b/GooglePlayInstant/InstallLauncher.cs
@@ -21,6 +21,21 @@ namespace GooglePlayInstant
     /// Provides methods that an instant app can use to display a Play Store install dialog. This dialog will allow
     /// the user to install the current instant app as a full app. This is an alternative to the Java-based
     /// <a href="https://developer.android.com/topic/google-play-instant/reference">Google Play Instant API</a>.
+    ///
+    /// Example code for the instant app's install button click handler:
+    /// <code>
+    /// using (var activity = InstallLauncher.GetCurrentActivity())
+    /// using (var postInstallIntent = InstallLauncher.CreatePostInstallIntent(activity))
+    /// {
+    ///     InstallLauncher.PutPostInstallIntentStringExtra(postInstallIntent, "payload", "test-payload");
+    ///     InstallLauncher.ShowInstallPrompt(activity, 123, postInstallIntent, "test-referrer");
+    /// }
+    /// </code>
+    ///
+    /// Example code for the installed app to retrieve the result:
+    /// <code>
+    /// Debug.LogErrorFormat("Post-install payload: {0}", InstallLauncher.GetPostInstallIntentStringExtra("payload"));
+    /// </code>
     /// </summary>
     public static class InstallLauncher
     {

--- a/GooglePlayInstant/Tests/Editor/AndroidManifest/AndroidManifestHelperTests.cs
+++ b/GooglePlayInstant/Tests/Editor/AndroidManifest/AndroidManifestHelperTests.cs
@@ -27,14 +27,9 @@ namespace GooglePlayInstant.Tests.Editor.AndroidManifest
         // The following constants are duplicated between AndroidManifestHelper and here since they are part of the
         // Android manifest schema. Changing one of these strings in AndroidManifestHelper should break a test.
         private const string Action = "action";
-        private const string ActionMain = "android.intent.action.MAIN";
-        private const string ActionView = "android.intent.action.VIEW";
         private const string Activity = "activity";
         private const string Application = "application";
         private const string Category = "category";
-        private const string CategoryBrowsable = "android.intent.category.BROWSABLE";
-        private const string CategoryDefault = "android.intent.category.DEFAULT";
-        private const string CategoryLauncher = "android.intent.category.LAUNCHER";
         private const string Data = "data";
         private const string DefaultUrl = "default-url";
         private const string IntentFilter = "intent-filter";
@@ -63,8 +58,8 @@ namespace GooglePlayInstant.Tests.Editor.AndroidManifest
         private static readonly XElement MainLauncherIntentFilter =
             new XElement(
                 IntentFilter,
-                new XElement(Action, new XAttribute(AndroidNameXName, ActionMain)),
-                new XElement(Category, new XAttribute(AndroidNameXName, CategoryLauncher)));
+                new XElement(Action, new XAttribute(AndroidNameXName, Android.IntentActionMain)),
+                new XElement(Category, new XAttribute(AndroidNameXName, Android.IntentCategoryLauncher)));
 
         private static readonly XElement MainActivityNoUrls =
             new XElement(Activity, new XAttribute(AndroidNameXName, MainActivityName), MainLauncherIntentFilter);
@@ -256,9 +251,9 @@ namespace GooglePlayInstant.Tests.Editor.AndroidManifest
             return new XElement(
                 IntentFilter,
                 new XAttribute(AndroidAutoVerifyXName, "true"),
-                new XElement(Action, new XAttribute(AndroidNameXName, ActionView)),
-                new XElement(Category, new XAttribute(AndroidNameXName, CategoryBrowsable)),
-                new XElement(Category, new XAttribute(AndroidNameXName, CategoryDefault)),
+                new XElement(Action, new XAttribute(AndroidNameXName, Android.IntentActionView)),
+                new XElement(Category, new XAttribute(AndroidNameXName, Android.IntentCategoryBrowsable)),
+                new XElement(Category, new XAttribute(AndroidNameXName, Android.IntentCategoryDefault)),
                 new XElement(Data, new XAttribute(AndroidSchemeXName, "http")),
                 new XElement(Data, new XAttribute(AndroidSchemeXName, "https")),
                 new XElement(Data, new XAttribute(AndroidHostXName, host)),


### PR DESCRIPTION
The ShowInstallPrompt method can be called from the click listener
of an "Install" button to launch a Play Store install dialog.

This is an easier-to-use alternative to the functionality provided by
including the instantapps-1.1.0.aar file in a Unity project and
calling showInstallPrompt:
https://developer.android.com/topic/google-play-instant/reference