### PR TITLE
Add a utility for finding the latest build-tools

### DIFF
--- a/GooglePlayInstant/Editor/AndroidBuildTools.cs
+++ b/GooglePlayInstant/Editor/AndroidBuildTools.cs
@@ -1,0 +1,109 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using GooglePlayInstant.Editor.GooglePlayServices;
+using UnityEngine;
+
+namespace GooglePlayInstant.Editor
+{
+    /// <summary>
+    /// Provides utility methods related to Android SDK build-tools.
+    /// </summary>
+    public static class AndroidBuildTools
+    {
+        private static readonly Regex VersionRegex =
+            new Regex(@"^(\d+)\.(\d+)\.(\d+)(-rc(\d+))?$", RegexOptions.Compiled);
+
+        /// <summary>
+        /// Returns the newest build-tools path as a string, or null if one couldn't be found.
+        /// </summary>
+        public static string GetNewestBuildToolsPath()
+        {
+            var buildToolsPath = Path.Combine(AndroidSdkManager.AndroidSdkRoot, "build-tools");
+            if (!Directory.Exists(buildToolsPath))
+            {
+                Debug.LogErrorFormat("Failed to locate build-tools path: {0}", buildToolsPath);
+                return null;
+            }
+
+            var directoryInfo = new DirectoryInfo(buildToolsPath);
+            var directoryNames = directoryInfo.GetDirectories().Select(dir => dir.Name);
+            var newestBuildTools = GetNewestVersion(directoryNames);
+            if (newestBuildTools == null)
+            {
+                Debug.LogErrorFormat("Failed to locate newest build-tools: {0}", buildToolsPath);
+                return null;
+            }
+
+            return Path.Combine(buildToolsPath, newestBuildTools);
+        }
+
+        // Visible for testing.
+        public static string GetNewestVersion(IEnumerable<string> versions)
+        {
+            if (versions == null)
+            {
+                return null;
+            }
+
+            var maxVersionLong = -1L;
+            string maxVersionString = null;
+            foreach (var versionString in versions)
+            {
+                var versionLong = ConvertVersionStringToLong(versionString);
+                if (versionLong > maxVersionLong)
+                {
+                    maxVersionLong = versionLong;
+                    maxVersionString = versionString;
+                }
+            }
+
+            return maxVersionString;
+        }
+
+        private static long ConvertVersionStringToLong(string versionString)
+        {
+            var match = VersionRegex.Match(versionString);
+            if (!match.Success)
+            {
+                return -1L;
+            }
+
+            var versionLong = 0L;
+            for (var i = 1; i <= 3; i++)
+            {
+                versionLong += long.Parse(match.Groups[i].Value);
+                // Multiply by a somewhat arbitrary value since major version outweighs minor version.
+                // This particular arbitrary value supports up to 4 digits per version component.
+                versionLong *= 10000L;
+            }
+
+            var releaseCandidateVersionGroup = match.Groups[5];
+            if (releaseCandidateVersionGroup.Success)
+            {
+                // Add the release candidate version, e.g. rc2 is newer than rc1.
+                versionLong += long.Parse(releaseCandidateVersionGroup.Value);
+                // But also subtract a little, since any "rc" is earlier than the equivalent release,
+                // e.g. "28.0.0-rc2" is older than "28.0.0".
+                versionLong -= 5000L;
+            }
+
+            return versionLong;
+        }
+    }
+}

--- a/GooglePlayInstant/Tests/Editor/AndroidBuildToolsTests.cs
+++ b/GooglePlayInstant/Tests/Editor/AndroidBuildToolsTests.cs
@@ -1,0 +1,85 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Linq;
+using GooglePlayInstant.Editor;
+using NUnit.Framework;
+
+namespace GooglePlayInstant.Tests.Editor
+{
+    [TestFixture]
+    public class AndroidBuildToolsTests
+    {
+        [Test]
+        public void TestGetNewestVersion_NullOrEmpty()
+        {
+            Assert.IsNull(AndroidBuildTools.GetNewestVersion(null));
+            Assert.IsNull(AndroidBuildTools.GetNewestVersion(Enumerable.Empty<string>()));
+        }
+
+        [Test]
+        public void TestGetNewestVersion_InvalidDirectoryNames()
+        {
+            AssertInvalid("");
+            AssertInvalid("abc");
+            AssertInvalid("a.b.c");
+            AssertInvalid("1");
+            AssertInvalid("1.2");
+            AssertInvalid("1.2-rc1");
+            AssertInvalid("1.2.3-rc");
+            AssertInvalid("1.2.3.4");
+            AssertInvalid("1.2.3.4-rc1");
+        }
+
+        [Test]
+        public void TestGetNewestVersion_ValidDirectoryNames()
+        {
+            AssertValid("0.0.0");
+            AssertValid("1.2.3");
+            AssertValid("1.2.3-rc0");
+            AssertValid("1.2.3-rc1");
+            AssertValid("100.200.300");
+        }
+
+        [Test]
+        public void TestGetNewestVersion_Multiple()
+        {
+            Assert.AreEqual("0.0.1", GetNewestVersion("0.0.1", "0.0.0"));
+            Assert.AreEqual("0.1.0", GetNewestVersion("0.0.1", "0.1.0"));
+            Assert.AreEqual("1.0.0", GetNewestVersion("1.0.0", "0.0.1"));
+            Assert.AreEqual("2.0.1", GetNewestVersion("1.2.3", "2.0.1"));
+            Assert.AreEqual("10.0.1", GetNewestVersion("9.99.99", "10.0.1"));
+            Assert.AreEqual("2.0.1-rc2", GetNewestVersion("2.0.1-rc2", "2.0.0"));
+            Assert.AreEqual("2.0.1-rc2", GetNewestVersion("2.0.1-rc2", "2.0.1-rc1"));
+            Assert.AreEqual("2.0.1", GetNewestVersion("2.0.1-rc2", "2.0.1"));
+            Assert.AreEqual("22.33.44", GetNewestVersion("22.33.44-rc55", "22.33.44"));
+        }
+
+        private static void AssertInvalid(string value)
+        {
+            Assert.IsNull(GetNewestVersion(value));
+        }
+
+        private static void AssertValid(string value)
+        {
+            Assert.AreEqual(value, GetNewestVersion(value));
+        }
+
+        // Helper method that converts a params array to an IEnumerable.
+        private static string GetNewestVersion(params string[] values)
+        {
+            return AndroidBuildTools.GetNewestVersion(values);
+        }
+    }
+}

--- a/GooglePlayInstant/Tests/Editor/AndroidBuildToolsTests.cs
+++ b/GooglePlayInstant/Tests/Editor/AndroidBuildToolsTests.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Linq;
 using GooglePlayInstant.Editor;
 using NUnit.Framework;
@@ -22,9 +23,14 @@ namespace GooglePlayInstant.Tests.Editor
     public class AndroidBuildToolsTests
     {
         [Test]
-        public void TestGetNewestVersion_NullOrEmpty()
+        public void TestGetNewestVersion_Null()
         {
-            Assert.IsNull(AndroidBuildTools.GetNewestVersion(null));
+            Assert.Throws<NullReferenceException>(() => AndroidBuildTools.GetNewestVersion(null));
+        }
+
+        [Test]
+        public void TestGetNewestVersion_Empty()
+        {
             Assert.IsNull(AndroidBuildTools.GetNewestVersion(Enumerable.Empty<string>()));
         }
 
@@ -49,14 +55,24 @@ namespace GooglePlayInstant.Tests.Editor
             AssertValid("1.2.3");
             AssertValid("1.2.3-rc0");
             AssertValid("1.2.3-rc1");
-            AssertValid("100.200.300");
+            AssertValid("9999.9999.9999");
+            AssertValid("9999.9999.9999-rc4999");
+        }
+
+        [Test]
+        public void TestGetNewestVersion_VersionTooBig()
+        {
+            Assert.Throws<ArgumentException>(() => GetNewestVersion("10000.9999.9999-rc4999"));
+            Assert.Throws<ArgumentException>(() => GetNewestVersion("9999.10000.9999-rc4999"));
+            Assert.Throws<ArgumentException>(() => GetNewestVersion("9999.9999.10000-rc4999"));
+            Assert.Throws<ArgumentException>(() => GetNewestVersion("9999.9999.9999-rc5000"));
         }
 
         [Test]
         public void TestGetNewestVersion_Multiple()
         {
             Assert.AreEqual("0.0.1", GetNewestVersion("0.0.1", "0.0.0"));
-            Assert.AreEqual("0.1.0", GetNewestVersion("0.0.1", "0.1.0"));
+            Assert.AreEqual("0.1.0", GetNewestVersion("0.0.0", "0.0.1", "0.1.0"));
             Assert.AreEqual("1.0.0", GetNewestVersion("1.0.0", "0.0.1"));
             Assert.AreEqual("2.0.1", GetNewestVersion("1.2.3", "2.0.1"));
             Assert.AreEqual("10.0.1", GetNewestVersion("9.99.99", "10.0.1"));

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ project.ext {
     pluginTestPath = file("${rootPath}/plugin-test")
     testLog = 'test.log'
 
-    pluginVersion = '0.6'
+    pluginVersion = '0.7'
     outputPluginPath = file("google-play-instant-plugin-${pluginVersion}.unitypackage").getPath()
 }
 


### PR DESCRIPTION
Upcoming features need access to the latest Android build-tools.
Add a utility method for finding this file path.

Also bump version to 0.7 for the next release.