### PR TITLE
Handle whitespace

### DIFF
--- a/GooglePlayInstant/Editor/ApkSigner.cs
+++ b/GooglePlayInstant/Editor/ApkSigner.cs
@@ -50,7 +50,11 @@ namespace GooglePlayInstant.Editor
         /// <returns>true if the specified APK uses APK Signature Scheme V2, false otherwise</returns>
         public static bool Verify(string apkPath)
         {
-            var arguments = string.Format("-jar {0} verify {1}", GetApkSignerJarPath(), apkPath);
+            var arguments = string.Format(
+                "-jar {0} verify {1}",
+                CommandLine.QuotePathIfNecessary(GetApkSignerJarPath()),
+                CommandLine.QuotePathIfNecessary(apkPath));
+
             var result = CommandLine.Run(JavaUtilities.JavaBinaryPath, arguments);
             if (result.exitCode == 0)
             {
@@ -107,7 +111,10 @@ namespace GooglePlayInstant.Editor
 
             var arguments = string.Format(
                 "-jar {0} sign --ks {1} --ks-key-alias {2} --pass-encoding utf-8 {3}",
-                GetApkSignerJarPath(), keystoreName, keyaliasName, apkPath);
+                CommandLine.QuotePathIfNecessary(GetApkSignerJarPath()),
+                CommandLine.QuotePathIfNecessary(keystoreName),
+                keyaliasName,
+                CommandLine.QuotePathIfNecessary(apkPath));
 
             var promptToPasswordDictionary = new Dictionary<string, string>
             {
@@ -181,6 +188,7 @@ namespace GooglePlayInstant.Editor
                 }
 
                 Flush();
+                // UTF8 to match "--pass-encoding utf-8" argument passed to apksigner.
                 foreach (var value in Encoding.UTF8.GetBytes(password + Environment.NewLine))
                 {
                     stdin.BaseStream.WriteByte(value);

--- a/GooglePlayInstant/Editor/ApkSigner.cs
+++ b/GooglePlayInstant/Editor/ApkSigner.cs
@@ -109,6 +109,10 @@ namespace GooglePlayInstant.Editor
                 return false;
             }
 
+            // This command will sign the APK file {3} using key {2} contained in keystore file {1}.
+            // ApkSignerResponder will provide passwords using the default method of stdin, so no need
+            // to specify "--ks-pass" or "--key-pass". ApkSignerResponder will encode the passwords
+            // with UTF8, so we specify "--pass-encoding utf-8" here.
             var arguments = string.Format(
                 "-jar {0} sign --ks {1} --ks-key-alias {2} --pass-encoding utf-8 {3}",
                 CommandLine.QuotePathIfNecessary(GetApkSignerJarPath()),

--- a/GooglePlayInstant/Editor/GooglePlayServices/CommandLine.cs
+++ b/GooglePlayInstant/Editor/GooglePlayServices/CommandLine.cs
@@ -670,6 +670,14 @@ namespace GooglePlayInstant.Editor.GooglePlayServices
                 toolPath, arguments, stdout, stderr, exitCode);
         }
 
+        /// <summary>
+        /// Returns the specified argument in double quotes if it contains at least one space, otherwise returns as is.
+        /// </summary>
+        public static string QuotePathIfNecessary(string path)
+        {
+            return path.Contains(" ") ? string.Format("\"{0}\"", path) : path;
+        }
+
 #if UNITY_EDITOR
         /// <summary>
         /// Get an executable extension.

--- a/GooglePlayInstant/Editor/PlayInstantBuildConfiguration.cs
+++ b/GooglePlayInstant/Editor/PlayInstantBuildConfiguration.cs
@@ -50,39 +50,40 @@ namespace GooglePlayInstant.Editor
         /// <summary>
         /// Optional field used to prevent removal of required components when building with engine stripping.
         /// <see cref="https://docs.unity3d.com/ScriptReference/BuildPlayerOptions-assetBundleManifestPath.html"/>
+        /// Never null.
         /// </summary>
         public static string AssetBundleManifestPath
         {
             get
             {
                 LoadConfigIfNecessary();
-                return _config.assetBundleManifestPath;
+                return _config.assetBundleManifestPath ?? string.Empty;
             }
         }
 
         /// <summary>
         /// Optional URL that can be used to launch this instant app. If empty, the app will be "URL-less" and
-        /// use an automatically created URL, e.g. https://instant.apps/package-name.
+        /// use an automatically created URL, e.g. https://instant.apps/package-name. Never null.
         /// </summary>
         public static string InstantUrl
         {
             get
             {
                 LoadConfigIfNecessary();
-                return _config.instantUrl;
+                return _config.instantUrl ?? string.Empty;
             }
         }
 
         /// <summary>
         /// Optional array of scenes to include in the build. If not specified, the enabled scenes from the
-        /// Unity "Build Settings" window will be used.
+        /// Unity "Build Settings" window will be used. Never null.
         /// </summary>
         public static string[] ScenesInBuild
         {
             get
             {
                 LoadConfigIfNecessary();
-                return _config.scenesInBuild;
+                return _config.scenesInBuild ?? new string[0];
             }
         }
 

--- a/GooglePlayInstant/Editor/PlayInstantBuilder.cs
+++ b/GooglePlayInstant/Editor/PlayInstantBuilder.cs
@@ -49,7 +49,7 @@ namespace GooglePlayInstant.Editor
         public static BuildPlayerOptions CreateBuildPlayerOptions(string apkPath, BuildOptions options)
         {
             var scenesInBuild = PlayInstantBuildConfiguration.ScenesInBuild;
-            if (scenesInBuild == null || scenesInBuild.Length == 0)
+            if (scenesInBuild.Length == 0)
             {
                 scenesInBuild = GetEditorBuildEnabledScenes();
             }

--- a/GooglePlayInstant/Editor/PlayInstantPublisher.cs
+++ b/GooglePlayInstant/Editor/PlayInstantPublisher.cs
@@ -49,7 +49,11 @@ namespace GooglePlayInstant.Editor
             }
 
             // Zip creation is fast enough so call jar synchronously rather than wait for post build AppDomain reset.
-            var arguments = string.Format("cvf {0} -C {1} {2}", zipFilePath, baseApkDirectory, BaseApkFileName);
+            var arguments = string.Format(
+                "cvf {0} -C {1} {2}",
+                CommandLine.QuotePathIfNecessary(zipFilePath),
+                CommandLine.QuotePathIfNecessary(baseApkDirectory),
+                BaseApkFileName);
             var result = CommandLine.Run(JavaUtilities.JarBinaryPath, arguments);
             if (result.exitCode == 0)
             {

--- a/GooglePlayInstant/Editor/PlayInstantRunner.cs
+++ b/GooglePlayInstant/Editor/PlayInstantRunner.cs
@@ -63,10 +63,13 @@ namespace GooglePlayInstant.Editor
             window.summaryText = "Installing app on device";
             window.bodyText = "The APK built successfully. Waiting for scripts to reload...\n";
             window.autoScrollToBottom = true;
-            window.CommandLineParams = new CommandLineParameters()
+            window.CommandLineParams = new CommandLineParameters
             {
                 FileName = JavaUtilities.JavaBinaryPath,
-                Arguments = string.Format("-jar {0} run {1}", jarPath, apkPath)
+                Arguments = string.Format(
+                    "-jar {0} run {1}",
+                    CommandLine.QuotePathIfNecessary(jarPath),
+                    CommandLine.QuotePathIfNecessary(apkPath))
             };
             window.CommandLineParams.AddEnvironmentVariable(
                 AndroidSdkManager.AndroidHome, AndroidSdkManager.AndroidSdkRoot);


### PR DESCRIPTION
Update all command line calls to wrap file/directory paths in double quotes
if the path contains at least one space.

Update the Build Settings screen to trim whitespace in text fields when
clicking "Save".

Fixes #19 