### PR TITLE
Introduce Quick Deploy

### DIFF
--- a/GooglePlayInstant/Editor/BuildSettingsWindow.cs
+++ b/GooglePlayInstant/Editor/BuildSettingsWindow.cs
@@ -35,6 +35,7 @@ namespace GooglePlayInstant.Editor
 #else
             new LegacyAndroidManifestUpdater();
 #endif
+        private static BuildSettingsWindow _windowInstance;
 
         private bool _isInstant;
         private string _instantUrl;
@@ -46,10 +47,23 @@ namespace GooglePlayInstant.Editor
         /// </summary>
         public static void ShowWindow()
         {
-            GetWindow(typeof(BuildSettingsWindow), true, WindowTitle);
+            _windowInstance = GetWindow(typeof(BuildSettingsWindow), true, WindowTitle) as BuildSettingsWindow;
+        }
+
+        private void OnDestroy()
+        {
+            _windowInstance = null;
         }
 
         private void Awake()
+        {
+            ReadFromBuildConfiguration();
+        }
+
+        /// <summary>
+        /// Read and update the window with most recent build configuration values.
+        /// </summary>
+        void ReadFromBuildConfiguration()
         {
             _isInstant = PlayInstantBuildConfiguration.IsInstantBuildType();
             _instantUrl = PlayInstantBuildConfiguration.InstantUrl;
@@ -57,8 +71,26 @@ namespace GooglePlayInstant.Editor
             _assetBundleManifestPath = PlayInstantBuildConfiguration.AssetBundleManifestPath;
         }
 
+        /// <summary>
+        /// Update window with most recent build configuration values if the window is open.
+        /// </summary>
+        public static void UpdateWindowIfOpen()
+        {
+            if (_windowInstance != null)
+            {
+                _windowInstance.ReadFromBuildConfiguration();
+                _windowInstance.Repaint();
+            }
+        }
+
         private void OnGUI()
         {
+            // Edge case that takes place when the plugin code gets re-compiled while this window is open.
+            if (_windowInstance == null)
+            {
+                _windowInstance = this;
+            }
+
             var descriptionTextStyle = new GUIStyle(GUI.skin.label)
             {
                 fontStyle = FontStyle.Italic,

--- a/GooglePlayInstant/Editor/PlayInstantEditorMenu.cs
+++ b/GooglePlayInstant/Editor/PlayInstantEditorMenu.cs
@@ -14,6 +14,7 @@
 
 using UnityEditor;
 using UnityEngine;
+using GooglePlayInstant.Editor.QuickDeploy;
 
 namespace GooglePlayInstant.Editor
 {
@@ -68,13 +69,31 @@ namespace GooglePlayInstant.Editor
             PlayInstantSdkInstaller.SetUp();
         }
 
-        [MenuItem("PlayInstant/Build for Play Console...", false, 300)]
+        [MenuItem("PlayInstant/Quick Deploy/Overview...", false, 300)]
+        private static void QuickDeployOverview()
+        {
+            QuickDeployWindow.ShowWindow(QuickDeployWindow.ToolBarSelectedButton.Overview);
+        }
+
+        [MenuItem("PlayInstant/Quick Deploy/AssetBundle Creation...", false, 301)]
+        private static void AssetBundleCreationSettings()
+        {
+            QuickDeployWindow.ShowWindow(QuickDeployWindow.ToolBarSelectedButton.CreateBundle);
+        }
+
+        [MenuItem("PlayInstant/Quick Deploy/Loading Screen...", false, 302)]
+        private static void LoadingScreenSettings()
+        {
+            QuickDeployWindow.ShowWindow(QuickDeployWindow.ToolBarSelectedButton.LoadingScreen);
+        }
+
+        [MenuItem("PlayInstant/Build for Play Console...", false, 400)]
         private static void BuildForPlayConsole()
         {
             PlayInstantPublishser.Build();
         }
 
-        [MenuItem("PlayInstant/Build and Run #%r", false, 301)]
+        [MenuItem("PlayInstant/Build and Run #%r", false, 401)]
         private static void BuildAndRun()
         {
             PlayInstantRunner.BuildAndRun();

--- a/GooglePlayInstant/Editor/QuickDeploy/AssetBundleBuilder.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/AssetBundleBuilder.cs
@@ -1,0 +1,68 @@
+﻿// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.IO;
+using UnityEditor;
+
+namespace GooglePlayInstant.Editor.QuickDeploy
+{
+    /// <summary>
+    /// Contains methods for building AssetBundle to be deployed.
+    /// </summary>
+    public static class AssetBundleBuilder
+    {
+        /// <summary>
+        /// Builds an AssetBundle containing scenes at given paths, and stores the AssetBundle at configured path.
+        /// </summary>
+        /// <param name="scenePaths">Paths to scenes to include in the AssetBundle. Should be relative to project directory.</param>
+        public static void BuildQuickDeployAssetBundle(string[] scenePaths)
+        {
+            if (scenePaths.Length == 0)
+            {
+                throw new Exception("No scenes were selected. Please select scenes to include in AssetBundle.");
+            }
+
+            if (string.IsNullOrEmpty(QuickDeployWindow.Config.AssetBundleFileName))
+            {
+                throw new Exception("Cannot build AssetBundle with invalid file name.");
+            }
+
+            var assetBundleBuild = new AssetBundleBuild();
+            assetBundleBuild.assetBundleName = Path.GetFileName(QuickDeployWindow.Config.AssetBundleFileName);
+            assetBundleBuild.assetNames = scenePaths;
+            var assetBundleDirectory = Path.GetDirectoryName(QuickDeployWindow.Config.AssetBundleFileName);
+            if (!Directory.Exists(assetBundleDirectory))
+            {
+                Directory.CreateDirectory(assetBundleDirectory);
+            }
+
+            var builtAssetBundleManifest = BuildPipeline.BuildAssetBundles(assetBundleDirectory,
+                new[] {assetBundleBuild}, BuildAssetBundleOptions.None, EditorUserBuildSettings.activeBuildTarget);
+            // Returned AssetBundleManifest will be null if there was error in building assetbundle.
+            if (builtAssetBundleManifest == null)
+            {
+                throw new Exception(
+                    "Could not build AssetBundle. Please ensure that you have properly configured AssetBundle to be built " +
+                    "by selecting scenes to include and choosing a valid path for AssetBundle to be stored.");
+            }
+
+            // Update AssetBundle manifest path in PlayInstantBuildConfiguration, and refresh the build settings window if it is open.
+            var builtAssetBundleManifestPath = string.Format("{0}.manifest", QuickDeployWindow.Config.AssetBundleFileName);
+            PlayInstantBuildConfiguration.SaveConfiguration(PlayInstantBuildConfiguration.InstantUrl,
+                PlayInstantBuildConfiguration.ScenesInBuild, builtAssetBundleManifestPath);
+            BuildSettingsWindow.UpdateWindowIfOpen();
+        }
+    }
+}

--- a/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/AssetBundleVerifierWindow.cs
@@ -1,0 +1,241 @@
+﻿// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Runtime.CompilerServices;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Networking;
+
+[assembly: InternalsVisibleTo("GooglePlayInstant.Tests.Editor.QuickDeploy")]
+
+namespace GooglePlayInstant.Editor.QuickDeploy
+{
+    /// <summary>
+    /// Window that verifies AssetBundles from given URLs.
+    /// </summary>
+    public class AssetBundleVerifierWindow : EditorWindow
+    {
+        public enum AssetBundleVerifyState
+        {
+            InProgress,
+            DestinationError,
+            WebRequestError,
+            BundleError,
+            DownloadSuccess
+        }
+
+        private const int FieldMinWidth = 170;
+        internal const string WebRequestErrorFormatMessage = "Problem retrieving AssetBundle from {0}: {1}";
+
+        private long _responseCode;
+
+        private string _mainScene;
+        private double _numOfMegabytes;
+        private UnityWebRequest _webRequest;
+        private AssetBundle _bundle;
+
+        // Visible for testing
+        internal bool AssetBundleDownloadIsSuccessful;
+        internal string AssetBundleUrl;
+        internal string ErrorDescription;
+
+        public AssetBundleVerifyState State;
+
+        /// <summary>
+        /// Creates a dialog box that details the success or failure of an AssetBundle retrieval from a given assetBundleUrl.
+        /// </summary>
+        public static AssetBundleVerifierWindow ShowWindow()
+        {
+            return (AssetBundleVerifierWindow) GetWindow(typeof(AssetBundleVerifierWindow), true,
+                "Play Instant AssetBundle Verify");
+        }
+
+        public void StartAssetBundleDownload(string assetBundleUrl)
+        {
+            if (string.IsNullOrEmpty(assetBundleUrl))
+            {
+                throw new ArgumentException("AssetBundle URL text field cannot be null or empty.");
+            }
+
+            AssetBundleUrl = assetBundleUrl;
+#if UNITY_2018_1_OR_NEWER
+            _webRequest = UnityWebRequestAssetBundle.GetAssetBundle(AssetBundleUrl);
+            _webRequest.SendWebRequest();
+#elif UNITY_2017_2_OR_NEWER
+            _webRequest = UnityWebRequest.GetAssetBundle(AssetBundleUrl);
+            _webRequest.SendWebRequest();
+#else
+            _webRequest = UnityWebRequest.GetAssetBundle(AssetBundleUrl);
+            _webRequest.Send();
+#endif
+        }
+
+        // Visible for testing
+        internal void HandleState(AssetBundleVerifyState state, UnityWebRequest webRequest)
+        {
+            // InProgress state should not be handled.
+            switch (state)
+            {
+                case AssetBundleVerifyState.DestinationError:
+                    AssetBundleDownloadIsSuccessful = false;
+                    ErrorDescription = "Cannot connect to destination host. See Console log for details.";
+                    // No need to log since debugging information in this case is logged from thrown exception.
+                    break;
+                case AssetBundleVerifyState.WebRequestError:
+                    AssetBundleDownloadIsSuccessful = false;
+                    ErrorDescription = webRequest.error;
+                    Debug.LogErrorFormat(WebRequestErrorFormatMessage, AssetBundleUrl,
+                        ErrorDescription);
+                    break;
+                case AssetBundleVerifyState.BundleError:
+                    AssetBundleDownloadIsSuccessful = false;
+                    ErrorDescription = "Error extracting AssetBundle. See Console log for details.";
+                    // No need to log since debugging information in this case is automatically logged by Unity.
+                    break;
+                case AssetBundleVerifyState.DownloadSuccess:
+                    AssetBundleDownloadIsSuccessful = true;
+                    _numOfMegabytes = ConvertBytesToMegabytes(webRequest.downloadedBytes);
+                    var scenes = _bundle.GetAllScenePaths();
+                    _mainScene = (scenes.Length == 0) ? "No scenes in AssetBundle" : scenes[0];
+                    // Free memory used by the AssetBundle since it will not be in use by the Editor. Set to true to destroy
+                    // all objects that were loaded from this bundle.
+                    _bundle.Unload(true);
+                    break;
+                default:
+                    var errorMessage =
+                        string.Format(
+                            "Unexpected state while checking the AssetBundle: {0}",
+                            state);
+                    throw new InvalidOperationException(errorMessage);
+            }
+        }
+
+        private AssetBundleVerifyState GetStateInfoFromDownload()
+        {
+            if (!_webRequest.isDone)
+            {
+                return AssetBundleVerifyState.InProgress;
+            }
+
+            try
+            {
+                _bundle = DownloadHandlerAssetBundle.GetContent(_webRequest);
+            }
+            catch (InvalidOperationException ex)
+            {
+                Debug.LogErrorFormat("Failed to obtain AssetBundle content: {0}", ex);
+                return AssetBundleVerifyState.DestinationError;
+            }
+
+            _responseCode = _webRequest.responseCode;
+
+#if UNITY_2017_1_OR_NEWER
+            if (_webRequest.isHttpError || _webRequest.isNetworkError)
+#else
+            if (_webRequest.isError)
+#endif
+            {
+                return AssetBundleVerifyState.WebRequestError;
+            }
+
+            if (_bundle == null)
+            {
+                return AssetBundleVerifyState.BundleError;
+            }
+
+            return AssetBundleVerifyState.DownloadSuccess;
+        }
+
+        private static double ConvertBytesToMegabytes(ulong bytes)
+        {
+            return bytes / 1024f / 1024f;
+        }
+
+        private void Update()
+        {
+            if (_webRequest == null)
+            {
+                return;
+            }
+
+            State = GetStateInfoFromDownload();
+
+            if (State == AssetBundleVerifyState.InProgress)
+            {
+                if (EditorUtility.DisplayCancelableProgressBar("AssetBundle Download", "",
+                    _webRequest.downloadProgress))
+                {
+                    _webRequest.Abort();
+                    _webRequest.Dispose();
+                    _webRequest = null;
+
+                    Debug.Log("Download process was cancelled.");
+                }
+
+                return;
+            }
+
+            // Performs download operation only once when webrequest is completed.
+            EditorUtility.ClearProgressBar();
+
+            HandleState(State, _webRequest);
+
+            Repaint();
+
+            // Turn request to null to signal ready for next call
+            _webRequest.Dispose();
+            _webRequest = null;
+        }
+
+        private void OnGUI()
+        {
+            if (State == AssetBundleVerifyState.InProgress)
+            {
+                EditorGUILayout.LabelField("Loading...");
+                return;
+            }
+
+            AddVerifyComponentInfo("AssetBundle Download Status:",
+                AssetBundleDownloadIsSuccessful ? "SUCCESS" : "FAILED");
+
+            AddVerifyComponentInfo("AssetBundle URL:",
+                string.IsNullOrEmpty(AssetBundleUrl) ? "N/A" : AssetBundleUrl);
+
+            AddVerifyComponentInfo("HTTP Status Code:", _responseCode == 0 ? "N/A" : _responseCode.ToString());
+
+            AddVerifyComponentInfo("Error Description:",
+                AssetBundleDownloadIsSuccessful ? "N/A" : ErrorDescription);
+
+            AddVerifyComponentInfo("Main Scene:", AssetBundleDownloadIsSuccessful ? _mainScene : "N/A");
+
+            AddVerifyComponentInfo("Size (MB):",
+                AssetBundleDownloadIsSuccessful ? _numOfMegabytes.ToString("#.####") : "N/A");
+
+            if (GUILayout.Button("Refresh"))
+            {
+                StartAssetBundleDownload(AssetBundleUrl);
+            }
+        }
+
+        private static void AddVerifyComponentInfo(string title, string response)
+        {
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.LabelField(title, GUILayout.MinWidth(FieldMinWidth));
+            EditorGUILayout.LabelField(response, EditorStyles.wordWrappedLabel);
+            EditorGUILayout.EndHorizontal();
+            EditorGUILayout.Space();
+        }
+    }
+}

--- a/GooglePlayInstant/Editor/QuickDeploy/DialogHelper.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/DialogHelper.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Runtime.Remoting.Messaging;
+using UnityEditor;
+using UnityEngine;
+
+namespace GooglePlayInstant.Editor.QuickDeploy
+{
+    /// <summary>
+    /// Utility class for displaying popup window messages.
+    /// </summary>
+    public static class DialogHelper
+    {
+
+        private const string OkButtonText = "OK";
+
+        /// <summary>
+        /// Displays a popup window that displays a message with a specified title.
+        /// </summary>
+        public static void DisplayMessage(string title, string message)
+        {
+            EditorUtility.DisplayDialog(title, message, OkButtonText);
+        }
+    }
+}

--- a/GooglePlayInstant/Editor/QuickDeploy/LoadingScreenGenerator.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/LoadingScreenGenerator.cs
@@ -1,0 +1,159 @@
+﻿// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.IO;
+using System.Runtime.CompilerServices;
+using GooglePlayInstant.LoadingScreen;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+
+[assembly: InternalsVisibleTo("GooglePlayInstant.Tests.Editor.QuickDeploy")]
+
+namespace GooglePlayInstant.Editor.QuickDeploy
+{
+    /// <summary>
+    /// Class that generates Unity loading scenes for instant apps.
+    /// </summary>
+    public class LoadingScreenGenerator
+    {
+        public const string SceneName = "play-instant-loading-screen-scene.unity";
+
+        public static readonly string SceneDirectoryPath =
+            Path.Combine("Assets", "PlayInstantLoadingScreen");
+
+        private const string CanvasName = "Loading Screen Canvas";
+
+        private const string SaveErrorTitle = "Loading Screen Save Error";
+
+        private static readonly string SceneFilePath =
+            Path.Combine(SceneDirectoryPath, SceneName);
+
+        /// <summary>
+        /// Creates a scene in the current project that acts as a loading scene until assetbundles are
+        /// downloaded from the CDN. Takes in a loadingScreenImagePath, a path to the image shown in the loading scene,
+        /// and an assetbundle URL. Replaces the current loading scene with a new one if it exists.
+        /// </summary>
+        public static void GenerateScene(string assetBundleUrl, string loadingScreenImagePath)
+        {
+            if (string.IsNullOrEmpty(assetBundleUrl))
+            {
+                throw new ArgumentException("AssetBundle URL text field cannot be null or empty.");
+            }
+
+            if (!File.Exists(loadingScreenImagePath))
+            {
+                throw new FileNotFoundException(string.Format("Loading screen image file cannot be found: {0}",
+                    loadingScreenImagePath));
+            }
+
+            // Removes the loading scene if it is present, otherwise does nothing.
+            EditorSceneManager.CloseScene(SceneManager.GetSceneByName(Path.GetFileNameWithoutExtension(SceneName)),
+                true);
+
+            var loadingScreenScene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene, NewSceneMode.Additive);
+
+            var loadingScreenGameObject = new GameObject(CanvasName);
+
+            AddImageToScene(loadingScreenGameObject, loadingScreenImagePath);
+
+            AddScript(loadingScreenGameObject);
+
+            LoadingBar.AddComponent(loadingScreenGameObject);
+
+            bool saveOk = EditorSceneManager.SaveScene(loadingScreenScene, SceneFilePath);
+
+            if (!saveOk)
+            {
+                // Not a fatal issue. User can attempt to resave this scene.
+                var warningMessage = string.Format("Issue while saving scene {0}.",
+                    SceneName);
+
+                Debug.LogWarning(warningMessage);
+
+                DialogHelper.DisplayMessage(SaveErrorTitle, warningMessage);
+            }
+            else
+            {
+                //TODO: investigate GUI Layout errors that occur when moving this to DialogHelper
+                if (EditorUtility.DisplayDialog("Change Scenes in Build",
+                    "Would you like to replace any existing Scenes in Build with the loading screen scene?", "Yes",
+                    "No"))
+                {
+                    SetMainSceneInBuild(SceneFilePath);
+                }
+            }
+        }
+
+        public static bool LoadingScreenExists()
+        {
+            return SceneManager.GetSceneByName(Path.GetFileNameWithoutExtension(SceneName)).IsValid();
+        }
+
+        public static GameObject GetLoadingScreenCanvasObject()
+        {
+            return GameObject.Find(CanvasName);
+        }
+
+        // Visible for testing
+        internal static void SetMainSceneInBuild(string pathToScene)
+        {
+            EditorBuildSettings.scenes = new[]
+            {
+                new EditorBuildSettingsScene(pathToScene, true)
+            };
+        }
+
+        // Visible for testing
+        internal static void AddScript(GameObject loadingScreenGameObject)
+        {
+            loadingScreenGameObject.AddComponent<LoadingScreenScript>();
+        }
+
+
+        // Visible for testing
+        internal static void AddImageToScene(GameObject loadingScreenGameObject,
+            string pathToLoadingScreenImage)
+        {
+            if (loadingScreenGameObject.GetComponent<Canvas>() == null)
+            {
+                // First time creating a loading screen, configure nested game objects appropriately.
+                var loadingScreenCanvas = loadingScreenGameObject.AddComponent<Canvas>();
+
+                loadingScreenCanvas.renderMode = RenderMode.ScreenSpaceOverlay;
+
+                loadingScreenGameObject.AddComponent<Image>();
+            }
+
+            var loadingScreenImageData = File.ReadAllBytes(pathToLoadingScreenImage);
+
+            var tex = new Texture2D(1, 1);
+
+            var texLoaded = tex.LoadImage(loadingScreenImageData);
+
+            if (!texLoaded)
+            {
+                throw new Exception("Failed to load image as a Texture2D.");
+            }
+
+            var loadingImageSprite = Sprite.Create(tex, new Rect(0, 0, tex.width, tex.height), new Vector2(0.5f, 0.5f));
+
+            var loadingScreenImage = loadingScreenGameObject.GetComponent<Image>();
+            loadingScreenImage.sprite = loadingImageSprite;
+        }
+    }
+}

--- a/GooglePlayInstant/Editor/QuickDeploy/PlayInstantSceneTreeView.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/PlayInstantSceneTreeView.cs
@@ -1,0 +1,157 @@
+﻿// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEditor.IMGUI.Controls;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace GooglePlayInstant.Editor.QuickDeploy
+{
+    /// <summary>
+    /// Class that encapsulates the TreeView representation of all scenes found in the current project.
+    /// </summary>
+    public class PlayInstantSceneTreeView : TreeView
+    {
+        private const int ToggleWidth = 18;
+        private readonly List<TreeViewItem> _allItems = new List<TreeViewItem>();
+        private int rowID = 0;
+
+        public PlayInstantSceneTreeView(TreeViewState treeViewState)
+            : base(treeViewState)
+        {
+            showAlternatingRowBackgrounds = true;
+            showBorder = true;
+            extraSpaceBeforeIconAndLabel = ToggleWidth;
+
+            Reload();
+        }
+
+        /// <summary>
+        /// Public inner class that extends the TreeViewItem representation of Scenes to include the enabled attribute.
+        /// </summary>
+        public class SceneItem : TreeViewItem
+        {
+            public bool Enabled;
+            public bool OldEnabledValue;
+            public string SceneBuildIndexString;
+            
+            public override bool Equals(object obj)
+            {
+                var that = obj as SceneItem;
+                return that != null && this.displayName.Equals(that.displayName);
+            }
+        }
+
+        public void AddOpenScenes()
+        {
+            var scenes = GetAllScenes();
+
+            for (var i = 0; i < scenes.Length; i++)
+            {
+                var sceneItem = new SceneItem
+                {
+                    id = rowID++,
+                    depth = 0,
+                    displayName = scenes[i].path,
+                    Enabled = true
+                };
+
+                if (!_allItems.Contains(sceneItem))
+                {
+                    _allItems.Add(sceneItem);
+                }
+            }
+
+            EditSceneBuildIndexString();
+            Reload();
+        }
+
+        private void EditSceneBuildIndexString()
+        {
+            var buildIndex = 0;
+            foreach (var item in _allItems)
+            {
+                var sceneItem = (SceneItem) item;
+                sceneItem.SceneBuildIndexString = sceneItem.Enabled ? "" + buildIndex++ : "";
+            }
+        }
+
+        protected override TreeViewItem BuildRoot()
+        {
+            var root = new TreeViewItem
+            {
+                id = 0,
+                depth = -1,
+                displayName = "Root"
+            };
+
+            SetupParentsAndChildrenFromDepths(root, _allItems);
+
+            return root;
+        }
+
+        private static Scene[] GetAllScenes()
+        {
+            var scenes = new Scene[SceneManager.sceneCount];
+            for (var i = 0; i < scenes.Length; i++)
+            {
+                scenes[i] = SceneManager.GetSceneAt(i);
+            }
+
+            return scenes;
+        }
+
+        protected override void RowGUI(RowGUIArgs args)
+        {
+            var toggleRect = args.rowRect;
+            toggleRect.x += GetContentIndent(args.item);
+            toggleRect.width = ToggleWidth;
+
+            var item = (SceneItem) args.item;
+
+            item.OldEnabledValue = item.Enabled;
+
+            item.Enabled = EditorGUI.Toggle(toggleRect, item.Enabled);
+
+            if (item.OldEnabledValue != item.Enabled)
+            {
+                EditSceneBuildIndexString();
+            }
+
+            DefaultGUI.LabelRightAligned(args.rowRect, item.SceneBuildIndexString, args.selected, args.focused);
+
+            base.RowGUI(args);
+
+            var current = Event.current;
+
+            if (args.rowRect.Contains(current.mousePosition) && current.type == EventType.ContextClick)
+            {
+                GenericMenu menu = new GenericMenu();
+                menu.AddItem(new GUIContent("Remove Selection"), false, RemoveScene, item);
+                menu.ShowAsContext();
+            }
+        }
+
+        private void RemoveScene(object item)
+        {
+            _allItems.Remove((SceneItem) item);
+            EditSceneBuildIndexString();
+            Reload();
+        }
+
+        //TODO: implement drag and drop
+    }
+}

--- a/GooglePlayInstant/Editor/QuickDeploy/QuickDeployConfig.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/QuickDeployConfig.cs
@@ -1,0 +1,170 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.IO;
+using GooglePlayInstant.LoadingScreen;
+using UnityEngine;
+
+namespace GooglePlayInstant.Editor.QuickDeploy
+{
+    /// <summary>
+    /// Contains a set of operations for storing and retrieving quick deploy configurations.
+    /// </summary>
+    public class QuickDeployConfig
+    {
+        private static readonly string EditorConfigurationFilePath =
+            Path.Combine("Library", "PlayInstantQuickDeployEditorConfig.json");
+
+        private static readonly string ResourcesDirectoryPath =
+            Path.Combine(LoadingScreenGenerator.SceneDirectoryPath, "Resources");
+
+        private static readonly string EngineConfigurationFilePath =
+            Path.Combine(ResourcesDirectoryPath, LoadingScreenConfig.EngineConfigurationFileName);
+
+        /// <summary>
+        /// The Editor Configuration singleton that should be used to read and modify Quick Deploy configuration.
+        /// Modified values are persisted by calling SaveEditorConfiguration.
+        /// </summary>
+        private EditorConfiguration EditorConfig;
+
+        /// <summary>
+        /// The Engine Configuration singleton that should be used to read and modify Loading Screen configuration.
+        /// Modified values are persisted by calling SaveEngineConfiguration.
+        /// </summary>
+        private LoadingScreenConfig.EngineConfiguration EngineConfig;
+
+        // Copy of fields from EditorConfig and EngineConfig for holding unsaved values set in the UI.
+        public string AssetBundleFileName;
+        public string AssetBundleUrl;
+
+        public void LoadConfiguration()
+        {
+            EditorConfig = LoadEditorConfiguration(EditorConfigurationFilePath);
+            EngineConfig = LoadEngineConfiguration(EngineConfigurationFilePath);
+            
+            // Copy of fields from EditorConfig and EngineConfig for holding unsaved values set in the UI.
+            AssetBundleFileName = EditorConfig.assetBundleFileName;
+            AssetBundleUrl = EngineConfig.assetBundleUrl;
+        }
+
+        /// <summary>
+        /// Store configuration from the current quick deploy tab to persistent storage.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if tab shouldn't have input fields.</exception>
+        public void SaveConfiguration(QuickDeployWindow.ToolBarSelectedButton currentTab)
+        {
+            switch (currentTab)
+            {
+                case QuickDeployWindow.ToolBarSelectedButton.CreateBundle:
+                    SaveEditorConfiguration(QuickDeployWindow.ToolBarSelectedButton.CreateBundle, EditorConfig,
+                        EditorConfigurationFilePath);
+                    break;
+                case QuickDeployWindow.ToolBarSelectedButton.LoadingScreen:
+                    SaveEngineConfiguration(QuickDeployWindow.ToolBarSelectedButton.LoadingScreen, EngineConfig,
+                        EngineConfigurationFilePath);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException("currentTab", currentTab, "Can't save from this tab.");
+            }
+        }
+
+        // Visible for testing
+        internal void SaveEditorConfiguration(QuickDeployWindow.ToolBarSelectedButton currentTab,
+            EditorConfiguration configuration, string editorConfigurationPath)
+        {
+            switch (currentTab)
+            {
+                case QuickDeployWindow.ToolBarSelectedButton.CreateBundle:
+                    configuration.assetBundleFileName = AssetBundleFileName;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException("currentTab", currentTab,
+                        "Can't save editor configurations from this tab.");
+            }
+
+            // Shouldn't hurt to write to persistent storage as long as SaveEditorConfiguration(currentTab) is only called
+            // when a major action happens.
+            File.WriteAllText(editorConfigurationPath, JsonUtility.ToJson(configuration));
+        }
+
+        // Visible for testing
+        internal void SaveEngineConfiguration(QuickDeployWindow.ToolBarSelectedButton currentTab,
+            LoadingScreenConfig.EngineConfiguration configuration, string engineConfigurationPath)
+        {
+            switch (currentTab)
+            {
+                case QuickDeployWindow.ToolBarSelectedButton.LoadingScreen:
+                    configuration.assetBundleUrl = AssetBundleUrl;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException("currentTab", currentTab,
+                        "Can't save engine configurations from this tab.");
+            }
+
+            Directory.CreateDirectory(ResourcesDirectoryPath);
+
+            // Shouldn't hurt to write to persistent storage as long as SaveEngineConfiguration(currentTab) is only called
+            // when a major action happens.
+            File.WriteAllText(engineConfigurationPath, JsonUtility.ToJson(configuration));
+        }
+
+        /// <summary>
+        /// De-serialize editor configuration file contents into EditorConfiguration instance if the file exists exists, otherwise
+        /// return Configuration instance with empty fields.
+        /// </summary>
+        internal EditorConfiguration LoadEditorConfiguration(string editorConfigurationPath)
+        {
+            if (!File.Exists(editorConfigurationPath))
+            {
+                return new EditorConfiguration();
+            }
+
+            var configurationJson = File.ReadAllText(editorConfigurationPath);
+            return JsonUtility.FromJson<EditorConfiguration>(configurationJson);
+        }
+
+        /// <summary>
+        /// De-serialize engine configuration file contents into EngineConfiguration instance if the file exists exists, otherwise
+        /// return Configuration instance with empty fields.
+        /// </summary>
+        internal LoadingScreenConfig.EngineConfiguration LoadEngineConfiguration(string engineConfigurationPath)
+        {
+            if (!File.Exists(engineConfigurationPath))
+            {
+                return new LoadingScreenConfig.EngineConfiguration();
+            }
+
+            var configurationJson = File.ReadAllText(engineConfigurationPath);
+            return JsonUtility.FromJson<LoadingScreenConfig.EngineConfiguration>(configurationJson);
+        }
+
+        /// <summary>
+        /// Returns true if an instance of the engine configuration exists.
+        /// </summary>
+        public static bool EngineConfigExists()
+        {
+            return File.Exists(EngineConfigurationFilePath);
+        }
+
+        /// <summary>
+        /// Represents JSON contents of the quick deploy configuration file.
+        /// </summary>
+        [Serializable]
+        public class EditorConfiguration
+        {
+            public string assetBundleFileName;
+        }
+    }
+}

--- a/GooglePlayInstant/Editor/QuickDeploy/QuickDeployWindow.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/QuickDeployWindow.cs
@@ -1,0 +1,398 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEditor.IMGUI.Controls;
+using UnityEngine;
+
+namespace GooglePlayInstant.Editor.QuickDeploy
+{
+    public class QuickDeployWindow : EditorWindow
+    {
+        /// <summary>
+        /// Saved configurations from a previous session.
+        /// </summary>
+        public static readonly QuickDeployConfig Config = new QuickDeployConfig();
+
+        private static readonly string[] ToolbarButtonNames =
+        {
+            "Overview", "Bundle Creation", "Loading Screen"
+        };
+
+        private static int _toolbarSelectedButtonIndex;
+
+        // Keep track of the previous tab to remove focus if user moves to a different tab. (b/112536394)
+        private static ToolBarSelectedButton _previousTab;
+
+        public enum ToolBarSelectedButton
+        {
+            Overview,
+            CreateBundle,
+            LoadingScreen
+        }
+
+        // Style that provides a light box background.
+        // Documentation: https://docs.unity3d.com/ScriptReference/GUISkin-textField.html
+        private const string UserInputGuiStyle = "textfield";
+
+        private const int WindowMinWidth = 475;
+        private const int WindowMinHeight = 400;
+
+        private const int SceneViewDeltaFromTop = 230;
+
+        private const int FieldMinWidth = 100;
+        private const int ShortButtonWidth = 100;
+        private const int ToolbarHeight = 25;
+
+        private string _loadingScreenImagePath;
+
+        // Titles for errors that occur
+        private const string AssetBundleBuildErrorTitle = "AssetBundle Build Error";
+        private const string AssetBundleCheckerErrorTitle = "AssetBundle Checker Error";
+        private const string LoadingScreenCreationErrorTitle = "Loading Screen Creation Error";
+        private const string LoadingScreenUpdateErrorTitle = "Loading Screen Update Error";
+
+        private PlayInstantSceneTreeView _playInstantSceneTreeTreeView;
+        private TreeViewState _treeViewState;
+
+        public static void ShowWindow(ToolBarSelectedButton select)
+        {
+            var window = GetWindow<QuickDeployWindow>(true, "Quick Deploy");
+
+            window.minSize = new Vector2(WindowMinWidth, WindowMinHeight);
+            _toolbarSelectedButtonIndex = (int) select;
+
+            Config.LoadConfiguration();
+        }
+
+        private void OnEnable()
+        {
+            _treeViewState = new TreeViewState();
+
+            _playInstantSceneTreeTreeView = new PlayInstantSceneTreeView(_treeViewState);
+        }
+
+        private void OnGUI()
+        {
+            _toolbarSelectedButtonIndex = GUILayout.Toolbar(_toolbarSelectedButtonIndex, ToolbarButtonNames,
+                GUILayout.MinHeight(ToolbarHeight));
+            var currentTab = (ToolBarSelectedButton) _toolbarSelectedButtonIndex;
+            UpdateGuiFocus(currentTab);
+            switch (currentTab)
+            {
+                case ToolBarSelectedButton.Overview:
+                    OnGuiOverviewSelect();
+                    break;
+                case ToolBarSelectedButton.CreateBundle:
+                    OnGuiCreateBundleSelect();
+                    break;
+                case ToolBarSelectedButton.LoadingScreen:
+                    OnGuiLoadingScreenSelect();
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Unfocus the window if the user has just moved to a different quick deploy tab.
+        /// </summary>
+        /// <param name="currentTab">A ToolBarSelectedButton instance representing the current quick deploy tab.</param>
+        /// <see cref="b/112536394"/>
+        private static void UpdateGuiFocus(ToolBarSelectedButton currentTab)
+        {
+            if (currentTab != _previousTab)
+            {
+                _previousTab = currentTab;
+                GUI.FocusControl(null);
+            }
+        }
+
+        private void OnGuiOverviewSelect()
+        {
+            var descriptionTextStyle = CreateDescriptionTextStyle();
+            EditorGUILayout.LabelField("About Quick Deploy", EditorStyles.boldLabel);
+            EditorGUILayout.BeginVertical(UserInputGuiStyle);
+            EditorGUILayout.Space();
+            EditorGUILayout.Space();
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.LabelField("Quick Deploy can significantly reduce the size of a Unity-based instant app " +
+                                       "by packaging some assets in an AssetBundle that is retrieved from a server " +
+                                       "during app startup.", descriptionTextStyle);
+            EditorGUILayout.EndHorizontal();
+            EditorGUILayout.Space();
+            EditorGUILayout.Space();
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.LabelField(
+                "Use the \"Bundle Creation\" tab to build an AssetBundle containing the game's " +
+                "main scene. Then upload the created AssetBundle to a server or CDN  " +
+                "and make the url endpoint public. Finally, use the \"Loading Screen\" tab to select an image to " +
+                "display on the loading screen and the URL that points to the uploaded AssetBundle.",
+                descriptionTextStyle);
+            EditorGUILayout.EndHorizontal();
+            EditorGUILayout.Space();
+            EditorGUILayout.Space();
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.LabelField(string.Format("Use Google Play Instant's \"{0}\" window to customize the " +
+                                                     "scenes included in the instant app. Then use the \"{1}\" menu " +
+                                                     "option to test the instant app loading the AssetBundle from the " +
+                                                     "remote server. Finally, select the \"{2}\" menu option to build " +
+                                                     "the app in a manner suitable for publishing on Play Console.",
+                "Build Settings", "Build and Run", "Build for Play Console"), descriptionTextStyle);
+            EditorGUILayout.EndHorizontal();
+            EditorGUILayout.Space();
+            EditorGUILayout.Space();
+            EditorGUILayout.EndVertical();
+        }
+
+        private void OnGuiCreateBundleSelect()
+        {
+            var descriptionTextStyle = CreateDescriptionTextStyle();
+
+            EditorGUILayout.LabelField("Create AssetBundle", EditorStyles.boldLabel);
+
+            EditorGUILayout.BeginVertical(UserInputGuiStyle);
+
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField("Select scenes to be put into an AssetBundle and then build it.",
+                descriptionTextStyle);
+
+            EditorGUILayout.Space();
+
+            EditorGUILayout.EndVertical();
+
+            EditorGUILayout.Space();
+
+            EditorGUILayout.BeginVertical(UserInputGuiStyle);
+            EditorGUILayout.Space();
+
+            _playInstantSceneTreeTreeView.OnGUI(GUILayoutUtility.GetRect(position.width,
+                position.height - SceneViewDeltaFromTop));
+            EditorGUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+            if (GUILayout.Button("Add Open Scenes"))
+            {
+                _playInstantSceneTreeTreeView.AddOpenScenes();
+            }
+
+            EditorGUILayout.EndHorizontal();
+            EditorGUILayout.Space();
+
+            EditorGUILayout.Space();
+
+
+            EditorGUILayout.BeginHorizontal();
+
+            EditorGUILayout.LabelField("AssetBundle File Path", GUILayout.MinWidth(FieldMinWidth));
+            Config.AssetBundleFileName = EditorGUILayout.TextField(Config.AssetBundleFileName,
+                GUILayout.MinWidth(FieldMinWidth));
+            EditorGUILayout.EndHorizontal();
+
+            EditorGUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+            if (GUILayout.Button("Browse", GUILayout.Width(ShortButtonWidth)))
+            {
+                Config.AssetBundleFileName = EditorUtility.SaveFilePanel("Save AssetBundle", "", "", "");
+                HandleDialogExit();
+            }
+
+            EditorGUILayout.EndHorizontal();
+
+            EditorGUILayout.BeginHorizontal();
+
+            if (GUILayout.Button("Build AssetBundle"))
+            {
+                try
+                {
+                    Config.SaveConfiguration(ToolBarSelectedButton.CreateBundle);
+                    AssetBundleBuilder.BuildQuickDeployAssetBundle(GetEnabledSceneItemPaths());
+                }
+                catch (Exception ex)
+                {
+                    DialogHelper.DisplayMessage(AssetBundleBuildErrorTitle,
+                        ex.Message);
+                    throw;
+                }
+
+                HandleDialogExit();
+            }
+
+            EditorGUILayout.EndHorizontal();
+        }
+
+        private string[] GetEnabledSceneItemPaths()
+        {
+            var scenes = _playInstantSceneTreeTreeView.GetRows();
+            var scenePaths = new List<string>();
+
+            foreach (var scene in scenes)
+            {
+                if (((PlayInstantSceneTreeView.SceneItem) scene).Enabled)
+                {
+                    scenePaths.Add(scene.displayName);
+                }
+            }
+
+            return scenePaths.ToArray();
+        }
+
+        private void OnGuiLoadingScreenSelect()
+        {
+            var descriptionTextStyle = CreateDescriptionTextStyle();
+
+            EditorGUILayout.LabelField("Set AssetBundle URL", EditorStyles.boldLabel);
+            EditorGUILayout.BeginVertical(UserInputGuiStyle);
+
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField(
+                "Specify the URL that points to the deployed AssetBundle. The AssetBundle will be downloaded at game startup. ",
+                descriptionTextStyle);
+            EditorGUILayout.Space();
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.LabelField("AssetBundle URL", GUILayout.MinWidth(FieldMinWidth));
+            Config.AssetBundleUrl =
+                EditorGUILayout.TextField(Config.AssetBundleUrl, GUILayout.MinWidth(FieldMinWidth));
+            EditorGUILayout.EndHorizontal();
+
+            EditorGUILayout.Space();
+
+            var setAssetBundleText = QuickDeployConfig.EngineConfigExists()
+                ? "Update AssetBundle URL"
+                : "Set AssetBundle URL";
+
+            if (GUILayout.Button(setAssetBundleText))
+            {
+                try
+                {
+                    Config.SaveConfiguration(ToolBarSelectedButton.LoadingScreen);
+                }
+                catch (Exception ex)
+                {
+                    DialogHelper.DisplayMessage(AssetBundleCheckerErrorTitle, ex.Message);
+
+                    throw;
+                }
+            }
+
+            EditorGUILayout.Space();
+            if (GUILayout.Button("Check AssetBundle"))
+            {
+                var window = AssetBundleVerifierWindow.ShowWindow();
+
+                try
+                {
+                    Config.SaveConfiguration(ToolBarSelectedButton.LoadingScreen);
+                    window.StartAssetBundleDownload(Config.AssetBundleUrl);
+                }
+                catch (Exception ex)
+                {
+                    DialogHelper.DisplayMessage(AssetBundleCheckerErrorTitle, ex.Message);
+
+                    window.Close();
+
+                    throw;
+                }
+            }
+
+            EditorGUILayout.Space();
+
+            EditorGUILayout.EndVertical();
+            EditorGUILayout.Space();
+
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField("Select Loading Screen Image", EditorStyles.boldLabel);
+            EditorGUILayout.BeginVertical(UserInputGuiStyle);
+            EditorGUILayout.Space();
+
+            EditorGUILayout.LabelField(
+                "Choose image to use as background for the loading scene.", descriptionTextStyle);
+            EditorGUILayout.Space();
+            EditorGUILayout.BeginHorizontal();
+            EditorGUILayout.LabelField("Image File Path", GUILayout.MinWidth(FieldMinWidth));
+
+            _loadingScreenImagePath =
+                EditorGUILayout.TextField(_loadingScreenImagePath, GUILayout.MinWidth(FieldMinWidth));
+
+            EditorGUILayout.EndHorizontal();
+            EditorGUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+            if (GUILayout.Button("Browse", GUILayout.Width(ShortButtonWidth)))
+            {
+                _loadingScreenImagePath =
+                    EditorUtility.OpenFilePanel("Select Image", "", "png,jpg,jpeg,tif,tiff,gif,bmp");
+                HandleDialogExit();
+            }
+
+            EditorGUILayout.EndHorizontal();
+            EditorGUILayout.Space();
+
+            if (LoadingScreenGenerator.LoadingScreenExists())
+            {
+                if (GUILayout.Button("Update Loading Scene"))
+                {
+                    try
+                    {
+                        Config.SaveConfiguration(ToolBarSelectedButton.LoadingScreen);
+                        LoadingScreenGenerator.AddImageToScene(LoadingScreenGenerator.GetLoadingScreenCanvasObject(),
+                            _loadingScreenImagePath);
+                    }
+                    catch (Exception ex)
+                    {
+                        DialogHelper.DisplayMessage(LoadingScreenUpdateErrorTitle, ex.Message);
+                        throw;
+                    }
+                }
+            }
+            else
+            {
+                if (GUILayout.Button("Create Loading Scene"))
+                {
+                    try
+                    {
+                        Config.SaveConfiguration(ToolBarSelectedButton.LoadingScreen);
+                        LoadingScreenGenerator.GenerateScene(Config.AssetBundleUrl,
+                            _loadingScreenImagePath);
+                    }
+                    catch (Exception ex)
+                    {
+                        DialogHelper.DisplayMessage(LoadingScreenCreationErrorTitle, ex.Message);
+                        throw;
+                    }
+                }
+            }
+
+            EditorGUILayout.Space();
+
+            EditorGUILayout.EndVertical();
+        }
+
+        // Call this method after any of the SaveFilePanels and OpenFilePanels placed inbetween BeginHorizontal()s or
+        // BeginVerticals()s. An error is thrown when a user switches contexts (into a different desktop), and the
+        // window reloads. After completing an action, this error is thrown. This method is called to avoid this.
+        //  Fix documentation: https://answers.unity.com/questions/1353442/editorutilitysavefilepane-and-beginhorizontal-caus.html
+        private void HandleDialogExit()
+        {
+            GUIUtility.ExitGUI();
+        }
+
+        private GUIStyle CreateDescriptionTextStyle()
+        {
+            return new GUIStyle(GUI.skin.label)
+            {
+                fontStyle = FontStyle.Italic,
+                wordWrap = true
+            };
+        }
+    }
+}

--- a/GooglePlayInstant/LoadingScreen/LoadingBar.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingBar.cs
@@ -1,0 +1,184 @@
+﻿// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace GooglePlayInstant.LoadingScreen
+{
+    /// <summary>
+    /// Class that encapsulates the creation and update of a Loading Bar component in the editor and during the game's
+    /// runtime.
+    /// </summary>
+    public static class LoadingBar
+    {
+        // TODO: revisit these arbitrarily chosen values
+        /// <summary>
+        /// Percentage of the loading bar allocated to the the asset bundle downloading process.
+        /// </summary>
+        public const float AssetBundleDownloadMaxWidthPercentage = .8f;
+
+        /// <summary>
+        /// Percentage of the loading bar allocated to the the scene loading process.
+        /// </summary>
+        public const float SceneLoadingMaxWidthPercentage = 1 - AssetBundleDownloadMaxWidthPercentage;
+
+        // Loading bar fill's padding against the loading bar outline.
+        private const int LoadingBarFillPadding = 17;
+
+        // Loading bar size as a proportion of the screen size. Adjust if needed.
+        private const float LoadingBarWidthProportion = 0.7f;
+        private const float LoadingBarHeightProportion = 0.02f;
+
+        // Loading bar placement as a proportion of the screen size relative to the bottom left corner. Adjust if needed.
+        private const float LoadingBarPositionX = 0.5f;
+        private const float LoadingBarPositionY = 0.3f;
+
+        // Names for the gameobject components
+        private const string LoadingBarGameObjectName = "Loading Bar";
+        private const string LoadingBarOutlineGameObjectName = "Loading Bar Outline";
+        private const string LoadingBarFillGameObjectName = "Loading Bar Fill";
+
+#if UNITY_EDITOR
+        /// <summary>
+        /// Creates a loading bar component on the specified loading screen game object's bottom half. Consists of
+        /// a white rounded border, with a colored loading bar fill in the middle.
+        /// </summary>
+        public static void AddComponent(GameObject loadingScreenGameObject)
+        {
+            var loadingBarGameObject = new GameObject(LoadingBarGameObjectName);
+            loadingBarGameObject.AddComponent<RectTransform>();
+            loadingBarGameObject.transform.SetParent(loadingScreenGameObject.transform);
+
+            SetOutline(loadingBarGameObject);
+            SetFill(loadingBarGameObject);
+        }
+
+        // TODO: check for compatibilty with unity 5.6+
+        private static void SetOutline(GameObject loadingBarGameObject)
+        {
+            var loadingBarOutlineGameObject = new GameObject(LoadingBarOutlineGameObjectName);
+            loadingBarOutlineGameObject.transform.SetParent(loadingBarGameObject.transform);
+
+            loadingBarOutlineGameObject.AddComponent<Image>();
+
+            var loadingBarOutlineImage = loadingBarOutlineGameObject.GetComponent<Image>();
+            loadingBarOutlineImage.sprite =
+                AssetDatabase.GetBuiltinExtraResource<Sprite>("UI/Skin/InputFieldBackground.psd");
+
+            loadingBarOutlineImage.type = Image.Type.Sliced;
+            loadingBarOutlineImage.fillCenter = false;
+
+            // Position outline component
+            loadingBarOutlineGameObject.transform.position = loadingBarGameObject.transform.position;
+        }
+
+        private static void SetFill(GameObject loadingBarGameObject)
+        {
+            var loadingBarFillGameObject = new GameObject(LoadingBarFillGameObjectName);
+            loadingBarFillGameObject.transform.SetParent(loadingBarGameObject.transform);
+
+            loadingBarFillGameObject.AddComponent<Image>();
+            var loadingBarFillImage = loadingBarFillGameObject.GetComponent<Image>();
+            loadingBarFillImage.color = Color.green;
+
+            // Position fill component
+            loadingBarFillGameObject.transform.position = loadingBarGameObject.transform.position;
+        }
+#endif
+
+        /// <summary>
+        /// Sets the position and size of the loading bar as a function of the screen height and width. 
+        /// </summary>
+        public static void UpdateSizeAndPostition()
+        {
+            var loadingBarRectTransform = GameObject.Find(LoadingBarGameObjectName).GetComponent<RectTransform>();
+            var loadingBarFillRectTransform =
+                GameObject.Find(LoadingBarFillGameObjectName).GetComponent<RectTransform>();
+            var loadingBarOutlineRectTransform =
+                GameObject.Find(LoadingBarOutlineGameObjectName).GetComponent<RectTransform>();
+
+            loadingBarRectTransform.position =
+                new Vector2(Screen.width * LoadingBarPositionX, Screen.height * LoadingBarPositionY);
+
+            loadingBarRectTransform.sizeDelta = new Vector2(Screen.width * LoadingBarWidthProportion,
+                Screen.height * LoadingBarHeightProportion);
+
+            loadingBarOutlineRectTransform.sizeDelta = loadingBarRectTransform.sizeDelta;
+            loadingBarFillRectTransform.sizeDelta =
+                new Vector2(0.0f, loadingBarRectTransform.sizeDelta.y - LoadingBarFillPadding);
+        }
+
+        /// <summary>
+        /// Resets the loading bar back to 0 percent.
+        /// </summary>
+        public static void Reset()
+        {
+            var loadingBarFillRectTransform =
+                GameObject.Find(LoadingBarFillGameObjectName).GetComponent<RectTransform>();
+
+            loadingBarFillRectTransform.sizeDelta =
+                new Vector2(0.0f, loadingBarFillRectTransform.sizeDelta.y);
+        }
+
+
+        /// <summary>
+        /// Updates a loading bar by the progress made by an asynchronous operation up to a specific percentage of
+        /// the loading bar. 
+        /// </summary>
+        public static IEnumerator Update(AsyncOperation operation, float percentageOfLoadingBar)
+        {
+            var loadingBarRectTransform = GameObject.Find(LoadingBarGameObjectName).GetComponent<RectTransform>();
+
+            var loadingBarFillRectTransform =
+                GameObject.Find(LoadingBarFillGameObjectName).GetComponent<RectTransform>();
+
+            // Total amount of space the loading bar can occupy
+            var loadingBarFillMaxWidth = loadingBarRectTransform.sizeDelta.x - LoadingBarFillPadding;
+
+            // Percentage of space that is allocated for this async operation
+            var loadingMaxWidth = loadingBarFillMaxWidth * percentageOfLoadingBar;
+
+            // Current width of the loading bar
+            var currentLoadingBarFill = loadingBarFillRectTransform.sizeDelta.x;
+
+            var loadingIsDone = false;
+
+            while (!loadingIsDone)
+            {
+                loadingBarFillRectTransform.sizeDelta = new Vector2(
+                    currentLoadingBarFill + loadingMaxWidth * operation.progress,
+                    loadingBarFillRectTransform.sizeDelta.y);
+
+                // Changing the width of the rectangle makes it shorter (or larger) on both sides--thus requiring
+                // the rectangle's x position to be moved left by half the amount it's been shortened.
+                loadingBarFillRectTransform.position = new Vector2(
+                    loadingBarRectTransform.position.x -
+                    (loadingBarFillMaxWidth - loadingBarFillRectTransform.sizeDelta.x) / 2f,
+                    loadingBarFillRectTransform.position.y);
+
+                if (operation.isDone)
+                {
+                    loadingIsDone = true;
+                }
+
+                yield return null;
+            }
+        }
+    }
+}

--- a/GooglePlayInstant/LoadingScreen/LoadingScreenConfig.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingScreenConfig.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace GooglePlayInstant.LoadingScreen
+{
+    /// <summary>
+    /// Class that represents the contents of the Loading Screen configuration json file, which notifies the loading scene
+    /// what URL to download the quick deploy application's main scene AssetBundle from.
+    /// </summary>
+    public class LoadingScreenConfig
+    {
+        /// <summary>
+        /// Name of the json file that contains Engine configurations
+        /// </summary>
+        public const string EngineConfigurationFileName = "PlayInstantQuickDeployEngineConfig.json";
+        
+        [Serializable]
+        public class EngineConfiguration
+        {
+            /// <summary>
+            /// URL of where the game's main AssetBundle is downloaded, and where the first scene is loaded from.
+            /// </summary>
+            public string assetBundleUrl;
+        }
+        
+    }
+}

--- a/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingScreenScript.cs
@@ -1,0 +1,110 @@
+﻿// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections;
+using System.IO;
+using UnityEngine;
+using UnityEngine.Networking;
+using UnityEngine.SceneManagement;
+
+namespace GooglePlayInstant.LoadingScreen
+{
+    /// <summary>
+    /// Script that starts on the loading screen. It works to download the game's AssetBundle from a specified url and
+    /// loads the first scene to start the game.
+    /// </summary>
+    public class LoadingScreenScript : MonoBehaviour
+    {
+        private const int MaxAttemptCount = 3;
+        private AssetBundle _bundle;
+        private int _assetBundleRetrievalAttemptCount;
+
+
+        private IEnumerator Start()
+        {
+            var loadingScreenConfigJsonTextAsset =
+                Resources.Load<TextAsset>(
+                    Path.GetFileNameWithoutExtension(LoadingScreenConfig.EngineConfigurationFileName));
+
+            if (loadingScreenConfigJsonTextAsset == null)
+            {
+                throw new FileNotFoundException(string.Format("{0} missing in Resources folder.",
+                    LoadingScreenConfig.EngineConfigurationFileName));
+            }
+
+            var loadingScreenConfigJson = loadingScreenConfigJsonTextAsset.ToString();
+
+            var loadingScreenConfig =
+                JsonUtility.FromJson<LoadingScreenConfig.EngineConfiguration>(loadingScreenConfigJson);
+
+            yield return GetAssetBundle(loadingScreenConfig.assetBundleUrl);
+
+            if (_bundle == null)
+            {
+                Debug.LogError("AssetBundle failed to be downloaded.");
+            }
+            else
+            {
+                var sceneLoadOperation = SceneManager.LoadSceneAsync(_bundle.GetAllScenePaths()[0]);
+
+                yield return LoadingBar.Update(sceneLoadOperation, LoadingBar.SceneLoadingMaxWidthPercentage);
+            }
+        }
+
+        private IEnumerator GetAssetBundle(string assetBundleUrl)
+        {
+#if UNITY_2018_1_OR_NEWER
+            var webRequest = UnityWebRequestAssetBundle.GetAssetBundle(assetBundleUrl);
+            var assetbundleDownloadOperation = webRequest.SendWebRequest();
+#elif UNITY_2017_2_OR_NEWER
+            var webRequest = UnityWebRequest.GetAssetBundle(assetBundleUrl);
+            var assetbundleDownloadOperation = webRequest.SendWebRequest();
+#else
+            var webRequest = UnityWebRequest.GetAssetBundle(assetBundleUrl);
+            var assetbundleDownloadOperation = webRequest.Send();
+#endif
+            LoadingBar.UpdateSizeAndPostition();
+
+            yield return LoadingBar.Update(assetbundleDownloadOperation,
+                LoadingBar.AssetBundleDownloadMaxWidthPercentage);
+
+#if UNITY_2017_1_OR_NEWER
+            if (webRequest.isHttpError || webRequest.isNetworkError)
+#else
+            if (webRequest.isError)
+#endif
+            {
+                if (_assetBundleRetrievalAttemptCount < MaxAttemptCount)
+                {
+                    _assetBundleRetrievalAttemptCount++;
+                    Debug.LogFormat("Attempt #{0} at downloading AssetBundle...", _assetBundleRetrievalAttemptCount);
+                    yield return new WaitForSeconds(2);
+
+                    //TODO: revisit this methodology of setting the loading bar
+                    LoadingBar.Reset();
+
+                    yield return GetAssetBundle(assetBundleUrl);
+                }
+                else
+                {
+                    Debug.LogErrorFormat("Error downloading asset bundle: {0}", webRequest.error);
+                }
+            }
+            else
+            {
+                _bundle = DownloadHandlerAssetBundle.GetContent(webRequest);
+            }
+        }
+    }
+}

--- a/GooglePlayInstant/Samples/SphereBlast/scripts/AssetBundleDownloader.cs
+++ b/GooglePlayInstant/Samples/SphereBlast/scripts/AssetBundleDownloader.cs
@@ -26,7 +26,11 @@ public class AssetBundleDownloader : MonoBehaviour
         // Cleans local cache of asset bundles. 
         // This here for download validation purposes
         // and should be removed from published builds
+#if UNITY_2017_1_OR_NEWER
         Caching.ClearCache();
+#else
+        Caching.CleanCache();
+#endif
         // Download and load required scenes
         yield return StartCoroutine(
             DownloadAsset(AssetBundleUrl, true));

--- a/GooglePlayInstant/Tests/Editor/QuickDeploy/AssetBundleVerifierTest.cs
+++ b/GooglePlayInstant/Tests/Editor/QuickDeploy/AssetBundleVerifierTest.cs
@@ -1,0 +1,75 @@
+﻿// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using GooglePlayInstant.Editor.QuickDeploy;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.Networking;
+using UnityEngine.TestTools;
+
+namespace GooglePlayInstant.Tests.Editor.QuickDeploy
+{
+    /// <summary>
+    /// Contains tests for each of AssetBundleVerifier error states.
+    /// </summary>
+    [TestFixture]
+    public class AssetBundleVerifierTest
+    {
+        [Test]
+        public void TestDestinationError()
+        {
+            var window = AssetBundleVerifierWindow.ShowWindow();
+
+            window.HandleState(AssetBundleVerifierWindow.AssetBundleVerifyState.DestinationError,
+                new UnityWebRequest());
+
+            Assert.IsFalse(window.AssetBundleDownloadIsSuccessful,
+                "AssetBundle download should not be marked successful during destination error state.");
+
+            window.Close();
+        }
+
+        [Test]
+        public void TestWebRequestError()
+        {
+            var window = AssetBundleVerifierWindow.ShowWindow();
+
+            window.HandleState(AssetBundleVerifierWindow.AssetBundleVerifyState.WebRequestError,
+                new UnityWebRequest());
+
+            Assert.IsFalse(window.AssetBundleDownloadIsSuccessful,
+                "AssetBundle download should not be marked successful during destination error state.");
+
+            LogAssert.Expect(LogType.Error,
+                string.Format(AssetBundleVerifierWindow.WebRequestErrorFormatMessage, window.AssetBundleUrl,
+                    window.ErrorDescription));
+
+            window.Close();
+        }
+
+        [Test]
+        public void TestBundleError()
+        {
+            var window = AssetBundleVerifierWindow.ShowWindow();
+
+            window.HandleState(AssetBundleVerifierWindow.AssetBundleVerifyState.BundleError,
+                new UnityWebRequest());
+
+            Assert.IsFalse(window.AssetBundleDownloadIsSuccessful,
+                "AssetBundle download should not be marked successful during bundle error state.");
+
+            window.Close();
+        }
+    }
+}

--- a/GooglePlayInstant/Tests/Editor/QuickDeploy/ConfigurationTest.cs
+++ b/GooglePlayInstant/Tests/Editor/QuickDeploy/ConfigurationTest.cs
@@ -1,0 +1,148 @@
+﻿// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.IO;
+using GooglePlayInstant.Editor.QuickDeploy;
+using GooglePlayInstant.LoadingScreen;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+
+namespace GooglePlayInstant.Tests.Editor.QuickDeploy
+{
+    public class ConfigurationTest
+    {
+        private static readonly string TestConfigurationPath =
+            Path.Combine("Assets", LoadingScreenConfig.EngineConfigurationFileName);
+
+        // Dispose of temporarily created file.  
+        [TearDown]
+        public void Cleanup()
+        {
+            AssetDatabase.DeleteAsset(TestConfigurationPath);
+        }
+
+        [Test]
+        public void TestSavingConfigOnCreateBundleWithString()
+        {
+            var quickDeployConfig = new QuickDeployConfig
+            {
+                AssetBundleFileName = "testbundle"
+            };
+            var inputConfig = new QuickDeployConfig.EditorConfiguration();
+
+            quickDeployConfig.SaveEditorConfiguration(QuickDeployWindow.ToolBarSelectedButton.CreateBundle, inputConfig,
+                TestConfigurationPath);
+
+            var outputConfigurationJson = File.ReadAllText(TestConfigurationPath);
+            var outputConfig =
+                JsonUtility.FromJson<QuickDeployConfig.EditorConfiguration>(outputConfigurationJson);
+
+            Assert.AreEqual(outputConfig.assetBundleFileName, quickDeployConfig.AssetBundleFileName);
+        }
+
+        [Test]
+        public void TestSavingConfigOnCreateBundleWithEmptyString()
+        {
+            var quickDeployConfig = new QuickDeployConfig
+            {
+                AssetBundleFileName = ""
+            };
+
+            var inputConfig = new QuickDeployConfig.EditorConfiguration();
+
+            quickDeployConfig.SaveEditorConfiguration(QuickDeployWindow.ToolBarSelectedButton.CreateBundle, inputConfig,
+                TestConfigurationPath);
+
+            var outputConfigurationJson = File.ReadAllText(TestConfigurationPath);
+            var outputConfig =
+                JsonUtility.FromJson<QuickDeployConfig.EditorConfiguration>(outputConfigurationJson);
+
+            Assert.IsEmpty(outputConfig.assetBundleFileName);
+        }
+
+        [Test]
+        public void TestSavingConfigOnLoadingScreenWithString()
+        {
+            var quickDeployConfig = new QuickDeployConfig
+            {
+                AssetBundleUrl = "testurl"
+            };
+
+            var inputConfig = new LoadingScreenConfig.EngineConfiguration();
+
+            quickDeployConfig.SaveEngineConfiguration(QuickDeployWindow.ToolBarSelectedButton.LoadingScreen,
+                inputConfig,
+                TestConfigurationPath);
+
+            var outputConfigurationJson = File.ReadAllText(TestConfigurationPath);
+            var outputConfig =
+                JsonUtility.FromJson<LoadingScreenConfig.EngineConfiguration>(outputConfigurationJson);
+
+            Assert.AreEqual(outputConfig.assetBundleUrl, quickDeployConfig.AssetBundleUrl);
+        }
+
+        [Test]
+        public void TestSavingConfigOnLoadingScreenWithEmptyString()
+        {
+            var quickDeployConfig = new QuickDeployConfig
+            {
+                AssetBundleUrl = ""
+            };
+
+            var inputConfig = new LoadingScreenConfig.EngineConfiguration();
+
+            quickDeployConfig.SaveEngineConfiguration(QuickDeployWindow.ToolBarSelectedButton.LoadingScreen,
+                inputConfig,
+                TestConfigurationPath);
+
+            var outputConfigurationJson = File.ReadAllText(TestConfigurationPath);
+            var outputConfig =
+                JsonUtility.FromJson<LoadingScreenConfig.EngineConfiguration>(outputConfigurationJson);
+
+            Assert.IsEmpty(outputConfig.assetBundleUrl);
+        }
+
+        [Test]
+        public void TestLoadingEditorConfiguration()
+        {
+            var quickDeployConfig = new QuickDeployConfig();
+
+            var inputConfig = new QuickDeployConfig.EditorConfiguration
+            {
+                assetBundleFileName = "testbundle"
+            };
+
+            File.WriteAllText(TestConfigurationPath, JsonUtility.ToJson(inputConfig));
+
+            var outputConfig = quickDeployConfig.LoadEditorConfiguration(TestConfigurationPath);
+
+            Assert.AreEqual(inputConfig.assetBundleFileName, outputConfig.assetBundleFileName);
+        }
+
+        [Test]
+        public void TestLoadingEngineConfiguration()
+        {
+            var quickDeployConfig = new QuickDeployConfig();
+
+            var inputConfig = new LoadingScreenConfig.EngineConfiguration {assetBundleUrl = "testurl"};
+
+            File.WriteAllText(TestConfigurationPath, JsonUtility.ToJson(inputConfig));
+
+            var outputConfig = quickDeployConfig.LoadEngineConfiguration(TestConfigurationPath);
+
+            Assert.AreEqual(inputConfig.assetBundleUrl, outputConfig.assetBundleUrl);
+        }
+    }
+}

--- a/GooglePlayInstant/Tests/Editor/QuickDeploy/LoadingScreenGeneratorTest.cs
+++ b/GooglePlayInstant/Tests/Editor/QuickDeploy/LoadingScreenGeneratorTest.cs
@@ -1,0 +1,74 @@
+﻿// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.IO;
+using GooglePlayInstant.Editor.QuickDeploy;
+using GooglePlayInstant.LoadingScreen;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace GooglePlayInstant.Tests.Editor.QuickDeploy
+{
+    /// <summary>
+    /// Contains unit tests for LoadingScreenGenerator methods.
+    /// </summary>
+    [TestFixture]
+    public class LoadingScreenGeneratorTest
+    {
+        private const string TestGameObjectName = "Testing Object";
+
+        [Test]
+        public void TestSetMainSceneInBuild()
+        {
+            var scene = EditorSceneManager.NewScene(NewSceneSetup.EmptyScene);
+            LoadingScreenGenerator.SetMainSceneInBuild(scene.path);
+
+            Assert.AreEqual(EditorBuildSettings.scenes.Length, 1,
+                "There should be only one scene in Build Settings.");
+
+            Assert.AreEqual(EditorBuildSettings.scenes[0].path, scene.path,
+                "The new scene built should be identical to the one in Build Settings.");
+        }
+
+        [Test]
+        public void TestAddLoadingScreenScript()
+        {
+            var loadingScreenGameObject = new GameObject(TestGameObjectName);
+            LoadingScreenGenerator.AddScript(loadingScreenGameObject);
+            Assert.IsNotNull(loadingScreenGameObject.GetComponent<LoadingScreenScript>(),
+                "A script should be attached to the loading screen object.");
+        }
+
+        [Test]
+        public void TestAddLoadingScreenImage()
+        {
+            const string testImage = "example.png";
+
+            // Create an empty test file by immediately closing the FileStream returned by File.Create().
+            using (File.Create(testImage)) ;
+
+            var loadingScreenGameObject = new GameObject(TestGameObjectName);
+
+            LoadingScreenGenerator.AddImageToScene(loadingScreenGameObject, testImage);
+
+            Assert.IsNotNull(loadingScreenGameObject.GetComponent<Canvas>(),
+                "A canvas component should have been added to the loading screen game object.");
+            Assert.IsNotNull(loadingScreenGameObject.GetComponent<Image>(),
+                "An image component should have been added to the loading screen game object.");
+        }
+    }
+}


### PR DESCRIPTION
One way to reduce the size of a Unity-based instant app is to place some assets in an AssetBundle and download that AssetBundle from a loading screen at game startup.

Quick Deploy makes it easier to use AssetBundles in this fashion via two main features:
 - it simplifies the creation of an AssetBundle from existing scenes
 - it provides a loading screen that displays progress in downloading the AssetBundle from a server