### PR TITLE
Quick Deploy - AssetBundle tab

### DIFF
--- a/GooglePlayInstant/Editor/QuickDeploy/AssetBundleBuilder.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/AssetBundleBuilder.cs
@@ -63,6 +63,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             PlayInstantBuildConfiguration.SaveConfiguration(PlayInstantBuildConfiguration.InstantUrl,
                 PlayInstantBuildConfiguration.ScenesInBuild, builtAssetBundleManifestPath);
             BuildSettingsWindow.UpdateWindowIfOpen();
+            AssetDatabase.Refresh();
         }
     }
 }

--- a/GooglePlayInstant/Editor/QuickDeploy/LoadingScreenGenerator.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/LoadingScreenGenerator.cs
@@ -18,6 +18,7 @@ using System.Runtime.CompilerServices;
 using GooglePlayInstant.LoadingScreen;
 using UnityEditor;
 using UnityEditor.SceneManagement;
+using UnityEditor.VersionControl;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
@@ -89,13 +90,17 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             }
             else
             {
-                //TODO: investigate GUI Layout errors that occur when moving this to DialogHelper
-                if (EditorUtility.DisplayDialog("Change Scenes in Build",
-                    "Would you like to replace any existing Scenes in Build with the loading screen scene?", "Yes",
-                    "No"))
+                AssetDatabase.Refresh();
+                EditorApplication.delayCall += () =>
                 {
-                    SetMainSceneInBuild(SceneFilePath);
-                }
+                    //TODO: move this to DialogHelper
+                    if (EditorUtility.DisplayDialog("Change Scenes in Build",
+                        "Would you like to replace any existing Scenes in Build with the loading screen scene?", "Yes",
+                        "No"))
+                    {
+                        SetMainSceneInBuild(SceneFilePath);
+                    }
+                };
             }
         }
 

--- a/GooglePlayInstant/Editor/QuickDeploy/QuickDeployConfig.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/QuickDeployConfig.cs
@@ -15,6 +15,7 @@
 using System;
 using System.IO;
 using GooglePlayInstant.LoadingScreen;
+using UnityEditor.IMGUI.Controls;
 using UnityEngine;
 
 namespace GooglePlayInstant.Editor.QuickDeploy
@@ -47,6 +48,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
 
         // Copy of fields from EditorConfig and EngineConfig for holding unsaved values set in the UI.
         public string AssetBundleFileName;
+        public PlayInstantSceneTreeView.State AssetBundleScenes;
         public string AssetBundleUrl;
 
         public void LoadConfiguration()
@@ -56,6 +58,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             
             // Copy of fields from EditorConfig and EngineConfig for holding unsaved values set in the UI.
             AssetBundleFileName = EditorConfig.assetBundleFileName;
+            AssetBundleScenes = EditorConfig.assetBundleScenes;
             AssetBundleUrl = EngineConfig.assetBundleUrl;
         }
 
@@ -88,6 +91,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             {
                 case QuickDeployWindow.ToolBarSelectedButton.CreateBundle:
                     configuration.assetBundleFileName = AssetBundleFileName;
+                    configuration.assetBundleScenes = AssetBundleScenes;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException("currentTab", currentTab,
@@ -165,6 +169,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         public class EditorConfiguration
         {
             public string assetBundleFileName;
+            public PlayInstantSceneTreeView.State assetBundleScenes;
         }
     }
 }

--- a/GooglePlayInstant/Editor/QuickDeploy/QuickDeployWindow.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/QuickDeployWindow.cs
@@ -15,7 +15,6 @@
 using System;
 using System.Collections.Generic;
 using UnityEditor;
-using UnityEditor.IMGUI.Controls;
 using UnityEngine;
 
 namespace GooglePlayInstant.Editor.QuickDeploy
@@ -66,23 +65,26 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         private const string LoadingScreenUpdateErrorTitle = "Loading Screen Update Error";
 
         private PlayInstantSceneTreeView _playInstantSceneTreeTreeView;
-        private TreeViewState _treeViewState;
 
         public static void ShowWindow(ToolBarSelectedButton select)
         {
             var window = GetWindow<QuickDeployWindow>(true, "Quick Deploy");
-
             window.minSize = new Vector2(WindowMinWidth, WindowMinHeight);
             _toolbarSelectedButtonIndex = (int) select;
-
-            Config.LoadConfiguration();
         }
 
         private void OnEnable()
         {
-            _treeViewState = new TreeViewState();
+            Config.LoadConfiguration();
+            
+            var scenesViewState = Config.AssetBundleScenes;
+            if (scenesViewState == null) scenesViewState = new PlayInstantSceneTreeView.State();
 
-            _playInstantSceneTreeTreeView = new PlayInstantSceneTreeView(_treeViewState);
+            _playInstantSceneTreeTreeView = new PlayInstantSceneTreeView(scenesViewState);
+            _playInstantSceneTreeTreeView.OnTreeStateChanged += (treeState) =>
+            {
+                Config.AssetBundleScenes = treeState;
+            };
         }
 
         private void OnGUI()

--- a/GooglePlayInstant/Editor/QuickDeploy/QuickDeployWindow.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/QuickDeployWindow.cs
@@ -77,8 +77,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         {
             Config.LoadConfiguration();
             
-            var scenesViewState = Config.AssetBundleScenes;
-            if (scenesViewState == null) scenesViewState = new PlayInstantSceneTreeView.State();
+            var scenesViewState = Config.AssetBundleScenes ?? new PlayInstantSceneTreeView.State();
 
             _playInstantSceneTreeTreeView = new PlayInstantSceneTreeView(scenesViewState);
             _playInstantSceneTreeTreeView.OnTreeStateChanged += (treeState) =>


### PR DESCRIPTION
* Refresh AssetDatabase when making AssetBundles so that the user can see them in their hierarchy immediately.

* Save selected scenes to config file.