### PR TITLE
Add App Bundle support for Unity 2018.3

### DIFF
--- a/GooglePlayInstant/Editor/AppBundlePublisher.cs
+++ b/GooglePlayInstant/Editor/AppBundlePublisher.cs
@@ -12,8 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if UNITY_2018_3_OR_NEWER
 using UnityEditor;
 using UnityEngine;
+#else
+using System;
+#endif
 
 namespace GooglePlayInstant.Editor
 {

--- a/GooglePlayInstant/Editor/AppBundlePublisher.cs
+++ b/GooglePlayInstant/Editor/AppBundlePublisher.cs
@@ -1,0 +1,51 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using UnityEditor;
+using UnityEngine;
+
+namespace GooglePlayInstant.Editor
+{
+    /// <summary>
+    /// Helper to build an Android App Bundle file suitable for publishing on Play Console.
+    /// </summary>
+    public static class AppBundlePublisher
+    {
+        /// <summary>
+        /// Builds an Android App Bundle.
+        /// </summary>
+        public static void Build()
+        {
+#if UNITY_2018_3_OR_NEWER
+            var aabFilePath = EditorUtility.SaveFilePanel("Create Android App Bundle", null, null, "aab");
+            if (string.IsNullOrEmpty(aabFilePath))
+            {
+                // Assume cancelled.
+                return;
+            }
+
+            Debug.LogFormat("Building app bundle: {0}", aabFilePath);
+            EditorUserBuildSettings.buildAppBundle = true;
+            var buildPlayerOptions = PlayInstantBuilder.CreateBuildPlayerOptions(aabFilePath, BuildOptions.None);
+            if (PlayInstantBuilder.Build(buildPlayerOptions))
+            {
+                // Do not log in case of failure. The method we called was responsible for logging.
+                Debug.LogFormat("Finished building app bundle: {0}", aabFilePath);
+            }
+#else
+            throw new InvalidOperationException("Android App Bundles are only supported on Unity 2018.3+");
+#endif
+        }
+    }
+}

--- a/GooglePlayInstant/Editor/PlayInstantBuilder.cs
+++ b/GooglePlayInstant/Editor/PlayInstantBuilder.cs
@@ -109,7 +109,12 @@ namespace GooglePlayInstant.Editor
 #endif
         }
 
-        private static bool Build(BuildPlayerOptions buildPlayerOptions)
+        /// <summary>
+        /// Builds a Play Instant APK or AAB based on the specified options.
+        /// Displays warning/error dialogs if there are issues during the build.
+        /// </summary>
+        /// <returns>True if the build succeeded, false if it failed or was cancelled.</returns>
+        public static bool Build(BuildPlayerOptions buildPlayerOptions)
         {
             if (!PlayInstantBuildConfiguration.IsInstantBuildType())
             {

--- a/GooglePlayInstant/Editor/PlayInstantEditorMenu.cs
+++ b/GooglePlayInstant/Editor/PlayInstantEditorMenu.cs
@@ -68,13 +68,21 @@ namespace GooglePlayInstant.Editor
             PlayInstantSdkInstaller.SetUp();
         }
 
-        [MenuItem("PlayInstant/Build for Play Console...", false, 300)]
+#if UNITY_2018_3_OR_NEWER
+        [MenuItem("PlayInstant/Build Android App Bundle...", false, 300)]
+        private static void BuildAndroidAppBundle()
+        {
+            AppBundlePublisher.Build();
+        }
+#endif
+
+        [MenuItem("PlayInstant/Build for Play Console...", false, 301)]
         private static void BuildForPlayConsole()
         {
-            PlayInstantPublishser.Build();
+            PlayInstantPublisher.Build();
         }
 
-        [MenuItem("PlayInstant/Build and Run #%r", false, 301)]
+        [MenuItem("PlayInstant/Build and Run #%r", false, 302)]
         private static void BuildAndRun()
         {
             PlayInstantRunner.BuildAndRun();

--- a/GooglePlayInstant/Editor/PlayInstantPublisher.cs
+++ b/GooglePlayInstant/Editor/PlayInstantPublisher.cs
@@ -22,7 +22,7 @@ namespace GooglePlayInstant.Editor
     /// <summary>
     /// Helper to build a ZIP file suitable for publishing on Play Console.
     /// </summary>
-    public static class PlayInstantPublishser
+    public static class PlayInstantPublisher
     {
         private const string BaseApkFileName = "base.apk";
 
@@ -37,6 +37,10 @@ namespace GooglePlayInstant.Editor
                 // Assume cancelled.
                 return;
             }
+
+#if UNITY_2018_3_OR_NEWER
+            EditorUserBuildSettings.buildAppBundle = false;
+#endif
 
             var baseApkDirectory = Path.GetTempPath();
             var baseApkPath = Path.Combine(baseApkDirectory, BaseApkFileName);

--- a/GooglePlayInstant/Editor/PlayInstantRunner.cs
+++ b/GooglePlayInstant/Editor/PlayInstantRunner.cs
@@ -53,6 +53,10 @@ namespace GooglePlayInstant.Editor
                 return;
             }
 
+#if UNITY_2018_3_OR_NEWER
+            EditorUserBuildSettings.buildAppBundle = false;
+#endif
+
             var apkPath = Path.Combine(Path.GetTempPath(), "temp.apk");
             Debug.LogFormat("Build and Run package location: {0}", apkPath);
 

--- a/GooglePlayInstant/Editor/PlayInstantSettingPolicy.cs
+++ b/GooglePlayInstant/Editor/PlayInstantSettingPolicy.cs
@@ -181,12 +181,21 @@ namespace GooglePlayInstant.Editor
 
                 case ScriptingImplementation.Mono2x:
                     policies.Add(new PlayInstantSettingPolicy(
-                        "Mono builds should use the highest code stripping level (micro mscorlib)",
+                        "Mono builds should use code stripping",
                         "This setting reduces APK size.",
+#if UNITY_2018_3_OR_NEWER
+                        () => PlayerSettings.GetManagedStrippingLevel(BuildTargetGroup.Android) ==
+                              ManagedStrippingLevel.Normal,
+                        () =>
+                        {
+                            PlayerSettings.SetManagedStrippingLevel(
+                                BuildTargetGroup.Android, ManagedStrippingLevel.Normal);
+#else
                         () => PlayerSettings.strippingLevel == StrippingLevel.UseMicroMSCorlib,
                         () =>
                         {
                             PlayerSettings.strippingLevel = StrippingLevel.UseMicroMSCorlib;
+#endif
                             return true;
                         }));
                     break;


### PR DESCRIPTION
Android App Bundles are natively supported as of Unity 2018.3; for
this version provide a menu option to build them. For other types
of builds, e.g. Build & Run, disable app bundle support.

Also change the managed code stripping policy to use the new
setting added in 2018.3.