### PR TITLE
Allow skipping Google Play Services signature check

### DIFF
--- a/GooglePlayInstant/Editor/PlayInstantBuildConfiguration.cs
+++ b/GooglePlayInstant/Editor/PlayInstantBuildConfiguration.cs
@@ -104,7 +104,7 @@ namespace GooglePlayInstant.Editor
         /// </summary>
         public static bool IsInstantBuildType()
         {
-            return IsPlayInstantScriptingSymbolDefined(GetScriptingDefineSymbols());
+            return IsScriptingSymbolDefined(GetScriptingDefineSymbols(), PlayInstantScriptingDefineSymbol);
         }
 
         /// <summary>
@@ -112,11 +112,7 @@ namespace GooglePlayInstant.Editor
         /// </summary>
         public static void SetInstantBuildType()
         {
-            var scriptingDefineSymbols = GetScriptingDefineSymbols();
-            if (!IsPlayInstantScriptingSymbolDefined(scriptingDefineSymbols))
-            {
-                SetScriptingDefineSymbols(scriptingDefineSymbols.Concat(new[] {PlayInstantScriptingDefineSymbol}));
-            }
+            AddScriptingDefineSymbol(PlayInstantScriptingDefineSymbol);
         }
 
         /// <summary>
@@ -125,15 +121,27 @@ namespace GooglePlayInstant.Editor
         public static void SetInstalledBuildType()
         {
             var scriptingDefineSymbols = GetScriptingDefineSymbols();
-            if (IsPlayInstantScriptingSymbolDefined(scriptingDefineSymbols))
+            if (IsScriptingSymbolDefined(scriptingDefineSymbols, PlayInstantScriptingDefineSymbol))
             {
                 SetScriptingDefineSymbols(scriptingDefineSymbols.Where(sym => sym != PlayInstantScriptingDefineSymbol));
             }
         }
 
-        private static bool IsPlayInstantScriptingSymbolDefined(string[] scriptingDefineSymbols)
+        /// <summary>
+        /// Adds the specified scripting define symbol for Android, but only if it isn't already defined.
+        /// </summary>
+        public static void AddScriptingDefineSymbol(string symbol)
         {
-            return Array.IndexOf(scriptingDefineSymbols, PlayInstantScriptingDefineSymbol) >= 0;
+            var scriptingDefineSymbols = GetScriptingDefineSymbols();
+            if (!IsScriptingSymbolDefined(scriptingDefineSymbols, symbol))
+            {
+                SetScriptingDefineSymbols(scriptingDefineSymbols.Concat(new[] {symbol}));
+            }
+        }
+
+        private static bool IsScriptingSymbolDefined(string[] scriptingDefineSymbols, string symbol)
+        {
+            return Array.IndexOf(scriptingDefineSymbols, symbol) >= 0;
         }
 
         private static string[] GetScriptingDefineSymbols()

--- a/GooglePlayInstant/PlaySignatureVerifier.cs
+++ b/GooglePlayInstant/PlaySignatureVerifier.cs
@@ -23,11 +23,23 @@ namespace GooglePlayInstant
     public static class PlaySignatureVerifier
     {
         /// <summary>
+        /// Scripting define symbol that causes <see cref="VerifyGooglePlayServices"/> to always return true.
+        /// </summary>
+        public const string SkipVerifyGooglePlayServicesScriptingDefineSymbol =
+            "PLAY_INSTANT_SKIP_VERIFY_GOOGLE_PLAY_SERVICES";
+
+        /// <summary>
         /// Returns true if Google Play Services is installed and its signature matches the expected value.
         /// </summary>
         public static bool VerifyGooglePlayServices(AndroidJavaObject packageManager)
         {
+#if PLAY_INSTANT_SKIP_VERIFY_GOOGLE_PLAY_SERVICES
+            // Some Google-internal builds of Google Play Services have a different signature.
+            Debug.Log("Skipped Google Play Services signature verification.");
+            return true;
+#else
             return VerifyGooglePlayPackage(packageManager, Android.GooglePlayServicesPackageName);
+#endif
         }
 
         private static bool VerifyGooglePlayPackage(AndroidJavaObject packageManager, string packageName)

--- a/GooglePlayInstant/Samples/TestApp/Editor/TestAppBuilder.cs
+++ b/GooglePlayInstant/Samples/TestApp/Editor/TestAppBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 Google LLC
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -60,6 +60,8 @@ namespace GooglePlayInstant.Samples.TestApp.Editor
                 return;
             }
 
+            PlayInstantBuildConfiguration.AddScriptingDefineSymbol(
+                PlaySignatureVerifier.SkipVerifyGooglePlayServicesScriptingDefineSymbol);
             PlayInstantBuildConfiguration.SaveConfiguration("", TestScenePaths, "");
             PlayInstantBuildConfiguration.SetInstantBuildType();
         }


### PR DESCRIPTION
Some Google internal builds need to skip the signature check.

Fixes #27