### PR TITLE
Add UI for downloading bundletool

### DIFF
--- a/GooglePlayInstant/Editor/Bundletool.cs
+++ b/GooglePlayInstant/Editor/Bundletool.cs
@@ -1,0 +1,105 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.IO;
+using GooglePlayInstant.Editor.GooglePlayServices;
+using UnityEngine;
+
+namespace GooglePlayInstant.Editor
+{
+    /// <summary>
+    /// Provides methods for <a href="https://developer.android.com/studio/command-line/bundletool">bundletool</a>.
+    /// </summary>
+    public static class Bundletool
+    {
+        public const string BundletoolVersion = "0.6.0";
+
+        /// <summary>
+        /// BundleTool config optimized for Unity-based instant apps.
+        /// Config definition: https://github.com/google/bundletool/blob/master/src/main/proto/config.proto
+        /// SplitsConfig:
+        ///  - Split on ABI so only one set of native libraries (armeabi-v7a, arm64-v8a, or x86) is sent to a device.
+        ///  - Do not split on LANGUAGE since Unity games don't store localized strings in the typical Android manner.
+        ///  - Do not split on SCREEN_DENSITY since Unity games don't have per-density resources other than app icons.
+        /// UncompressNativeLibraries: Instant apps have smaller over-the-wire and on-disk size with this enabled.
+        /// TODO: Consider fully uncompressed, i.e. ""compression"": { ""uncompressedGlob"": [""**/*""] }
+        /// </summary>
+        private const string BundleConfigJsonText = @"
+{
+  ""optimizations"": {
+        ""splitsConfig"": {
+            ""splitDimension"": [
+                {
+                    ""value"": ""ABI"",
+                    ""negate"": false
+                },
+                {
+                    ""value"": ""LANGUAGE"",
+                    ""negate"": true
+                },
+                {
+                    ""value"": ""SCREEN_DENSITY"",
+                    ""negate"": true
+                }
+            ]
+        },
+        ""uncompressNativeLibraries"": { ""enabled"": true }
+    }
+}";
+
+        /// <summary>
+        /// Returns the path to the bundletool jar within the project's Library directory.
+        /// </summary>
+        public static string GetBundletoolJarPath()
+        {
+            var library = Directory.CreateDirectory("Library");
+            return Path.Combine(library.FullName, string.Format("bundletool-all-{0}.jar", BundletoolVersion));
+        }
+
+        /// <summary>
+        /// Returns true if the expected version of bundletool is already located in the expected location,
+        /// and false if the file doesn't exist, in which case a dialog will be shown prompting to download it.
+        /// </summary>
+        public static bool CheckBundletool()
+        {
+            var bundletoolJarPath = GetBundletoolJarPath();
+            if (File.Exists(bundletoolJarPath))
+            {
+                return true;
+            }
+
+            Debug.LogWarningFormat("Failed to locate bundletool: {0}", bundletoolJarPath);
+            BundletoolDownloadWindow.ShowWindow();
+            return false;
+        }
+
+        /// <summary>
+        /// Builds an Android App Bundle at the specified location containing the specified base module.
+        /// </summary>
+        /// <returns>An error message if there was a problem running bundletool, or null if successful.</returns>
+        public static string BuildBundle(string baseModuleZip, string outputFile)
+        {
+            var bundleConfigJsonFile = Path.Combine(Path.GetTempPath(), "BundleConfig.json");
+            File.WriteAllText(bundleConfigJsonFile, BundleConfigJsonText);
+
+            var arguments = string.Format("-jar {0} build-bundle --config={1} --modules={2} --output={3}",
+                GetBundletoolJarPath(),
+                bundleConfigJsonFile,
+                baseModuleZip,
+                outputFile);
+            var result = CommandLine.Run(JavaUtilities.JavaBinaryPath, arguments);
+            return result.exitCode == 0 ? null : result.message;
+        }
+    }
+}

--- a/GooglePlayInstant/Editor/BundletoolDownloadWindow.cs
+++ b/GooglePlayInstant/Editor/BundletoolDownloadWindow.cs
@@ -17,6 +17,10 @@ using UnityEditor;
 using UnityEngine;
 using UnityEngine.Networking;
 
+#if !UNITY_2017_2_OR_NEWER
+using System.IO;
+#endif
+
 namespace GooglePlayInstant.Editor
 {
     /// <summary>

--- a/GooglePlayInstant/Editor/BundletoolDownloadWindow.cs
+++ b/GooglePlayInstant/Editor/BundletoolDownloadWindow.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -39,7 +38,7 @@ namespace GooglePlayInstant.Editor
                 "Bundletool is a command line java program used for creating Android App Bundles (.aab files). " +
                 "Bundletool is also used to generate a set of APKs from an .aab file.", EditorStyles.wordWrappedLabel);
             EditorGUILayout.Space();
-            CreateButton("Learn more",
+            WindowUtils.CreateRightAlignedButton("Learn more",
                 () => { Application.OpenURL("https://developer.android.com/studio/command-line/bundletool"); });
 
             EditorGUILayout.Space();
@@ -49,7 +48,7 @@ namespace GooglePlayInstant.Editor
             EditorGUILayout.LabelField(string.Format("Click \"Download\" to download bundletool version {0}.",
                 Bundletool.BundletoolVersion), EditorStyles.wordWrappedLabel);
             EditorGUILayout.Space();
-            CreateButton("Download", StartDownload);
+            WindowUtils.CreateRightAlignedButton("Download", StartDownload);
 
             GUI.enabled = true;
         }
@@ -146,18 +145,6 @@ namespace GooglePlayInstant.Editor
             _downloadRequest = UnityWebRequest.Get(bundletoolUri);
             _downloadRequest.Send();
 #endif
-        }
-
-        private static void CreateButton(string text, Action action)
-        {
-            EditorGUILayout.BeginHorizontal();
-            GUILayout.FlexibleSpace();
-            if (GUILayout.Button(text, GUILayout.Width(100)))
-            {
-                action();
-            }
-
-            EditorGUILayout.EndHorizontal();
         }
 
         /// <summary>

--- a/GooglePlayInstant/Editor/BundletoolDownloadWindow.cs
+++ b/GooglePlayInstant/Editor/BundletoolDownloadWindow.cs
@@ -1,0 +1,167 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace GooglePlayInstant.Editor
+{
+    /// <summary>
+    /// Downloads <a href="https://developer.android.com/studio/command-line/bundletool">bundletool</a>.
+    /// </summary>
+    public class BundletoolDownloadWindow : EditorWindow
+    {
+        private UnityWebRequest _downloadRequest;
+
+        private void OnGUI()
+        {
+            GUI.enabled = _downloadRequest == null;
+
+            EditorGUILayout.Space();
+            EditorGUILayout.LabelField(
+                "Bundletool is a command line java program used for creating Android App Bundles (.aab files). " +
+                "Bundletool is also used to generate a set of APKs from an .aab file.", EditorStyles.wordWrappedLabel);
+            EditorGUILayout.Space();
+            CreateButton("Learn more",
+                () => { Application.OpenURL("https://developer.android.com/studio/command-line/bundletool"); });
+
+            EditorGUILayout.Space();
+            EditorGUILayout.Space();
+            EditorGUILayout.Space();
+
+            EditorGUILayout.LabelField(string.Format("Click \"Download\" to download bundletool version {0}.",
+                Bundletool.BundletoolVersion), EditorStyles.wordWrappedLabel);
+            EditorGUILayout.Space();
+            CreateButton("Download", StartDownload);
+
+            GUI.enabled = true;
+        }
+
+        private void Update()
+        {
+            if (_downloadRequest == null)
+            {
+                return;
+            }
+
+            if (_downloadRequest.isDone)
+            {
+                EditorUtility.ClearProgressBar();
+
+#if UNITY_2017_1_OR_NEWER
+                if (_downloadRequest.isHttpError || _downloadRequest.isNetworkError)
+#else
+                if (_downloadRequest.isError)
+#endif
+                {
+                    var downloadRequestError = _downloadRequest.error;
+                    _downloadRequest.Dispose();
+                    _downloadRequest = null;
+
+                    Debug.LogErrorFormat("Bundletool download error: {0}", downloadRequestError);
+                    if (EditorUtility.DisplayDialog("Download Failed",
+                        downloadRequestError + "\n\nClick \"OK\" to retry.", "OK", "Cancel"))
+                    {
+                        StartDownload();
+                    }
+                    else
+                    {
+                        Close();
+                    }
+
+                    return;
+                }
+
+                // Download succeeded. Copy the bytes if this version of Unity doesn't support DownloadHandlerFile.
+                var bundletoolJarPath = Bundletool.GetBundletoolJarPath();
+#if !UNITY_2017_2_OR_NEWER
+                File.WriteAllBytes(bundletoolJarPath, _downloadRequest.downloadHandler.data);
+#endif
+                _downloadRequest.Dispose();
+                _downloadRequest = null;
+
+                Debug.LogFormat("Bundletool downloaded: {0}", bundletoolJarPath);
+                var message = string.Format(
+                    "Bundletool has been downloaded to your project's \"Library\" directory: {0}", bundletoolJarPath);
+                if (EditorUtility.DisplayDialog("Download Complete", message, "OK"))
+                {
+                    Close();
+                }
+
+                return;
+            }
+
+            // Download is in progress.
+            if (EditorUtility.DisplayCancelableProgressBar(
+                "Downloading bundletool", null, _downloadRequest.downloadProgress))
+            {
+                EditorUtility.ClearProgressBar();
+                _downloadRequest.Abort();
+                _downloadRequest.Dispose();
+                _downloadRequest = null;
+                Debug.Log("Cancelled bundletool download.");
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (_downloadRequest != null)
+            {
+                _downloadRequest.Dispose();
+                _downloadRequest = null;
+            }
+        }
+
+        private void StartDownload()
+        {
+            Debug.Log("Downloading bundletool...");
+            var bundletoolUri = string.Format(
+                "https://github.com/google/bundletool/releases/download/{0}/bundletool-all-{0}.jar",
+                Bundletool.BundletoolVersion);
+#if UNITY_2017_2_OR_NEWER
+            var downloadHandler = new DownloadHandlerFile(Bundletool.GetBundletoolJarPath())
+            {
+                removeFileOnAbort = true
+            };
+            _downloadRequest = new UnityWebRequest(bundletoolUri, UnityWebRequest.kHttpVerbGET, downloadHandler, null);
+            _downloadRequest.SendWebRequest();
+#else
+            _downloadRequest = UnityWebRequest.Get(bundletoolUri);
+            _downloadRequest.Send();
+#endif
+        }
+
+        private static void CreateButton(string text, Action action)
+        {
+            EditorGUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+            if (GUILayout.Button(text, GUILayout.Width(100)))
+            {
+                action();
+            }
+
+            EditorGUILayout.EndHorizontal();
+        }
+
+        /// <summary>
+        /// Displays this window, creating it if necessary.
+        /// </summary>
+        public static void ShowWindow()
+        {
+            GetWindow(typeof(BundletoolDownloadWindow), true, "Bundletool Download Required");
+        }
+    }
+}

--- a/GooglePlayInstant/Editor/WindowUtils.cs
+++ b/GooglePlayInstant/Editor/WindowUtils.cs
@@ -1,0 +1,40 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace GooglePlayInstant.Editor
+{
+    /// <summary>
+    /// Helper methods for working with <see cref="EditorWindow"/>.
+    /// </summary>
+    public static class WindowUtils
+    {
+        private const float ShortButtonWidth = 100.0f;
+
+        public static void CreateRightAlignedButton(string text, Action action)
+        {
+            EditorGUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+            if (GUILayout.Button(text, GUILayout.Width(ShortButtonWidth)))
+            {
+                action();
+            }
+
+            EditorGUILayout.EndHorizontal();
+        }
+    }
+}


### PR DESCRIPTION
Bundletool is required for creating Android App Bundles on versions of
Unity prior to 2018.3, and for creating sets of APKs from bundles.