### PR TITLE
Changed scene paths to be relative to the Asset folder

### DIFF
--- a/GooglePlayInstant/Editor/QuickDeploy/DialogHelper.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/DialogHelper.cs
@@ -110,8 +110,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             }
 
             var relativePath = absolutePath.Remove(index, parentPath.Length);
-            relativePath = Path.Combine("Assets/", relativePath);
-            return relativePath;
+            return Path.Combine("Assets", relativePath);
         }
     }
 }

--- a/GooglePlayInstant/Editor/QuickDeploy/LoadingScreenGenerator.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/LoadingScreenGenerator.cs
@@ -54,11 +54,6 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         /// </summary>
         public static void GenerateScene(string assetBundleUrl, Texture2D loadingScreenImage, string sceneFilePath)
         {
-            if (string.IsNullOrEmpty(assetBundleUrl))
-            {
-                throw new ArgumentException("AssetBundle URL text field cannot be null or empty.");
-            }
-
             // Removes the loading scene if it is present, otherwise does nothing.
             EditorSceneManager.CloseScene(SceneManager.GetSceneByName(Path.GetFileNameWithoutExtension(sceneFilePath)),
                 true);
@@ -67,7 +62,6 @@ namespace GooglePlayInstant.Editor.QuickDeploy
 
             PopulateScene(loadingScreenImage, assetBundleUrl);
 
-            // TODO: Change sceneFilePath to be relative to the Assets folder.
             bool saveOk = EditorSceneManager.SaveScene(loadingScreenScene, sceneFilePath);
 
             if (!saveOk)

--- a/GooglePlayInstant/Editor/QuickDeploy/QuickDeployWindow.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/QuickDeployWindow.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.IO;
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
@@ -289,14 +290,20 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         /// </summary>
         private void HandleCreateLoadingSceneButton()
         {
+            if (string.IsNullOrEmpty(Config.AssetBundleUrl))
+            {
+                DialogHelper.DisplayMessage(LoadingScreenCreationErrorTitle,
+                    "AssetBundle URL text field cannot be null or empty.");
+                return;
+            }
+
             string saveFilePath =
-                DialogHelper.SaveFilePanel("Create Loading Scene", Config.LoadingSceneFileName, "unity");
+                DialogHelper.SaveFilePanelInProject("Create Loading Scene", Config.LoadingSceneFileName, "unity");
             if (String.IsNullOrEmpty(saveFilePath))
             {
                 // Assume cancelled.
                 return;
             }
-
             Config.LoadingSceneFileName = saveFilePath;
 
             try


### PR DESCRIPTION
`EditorUtility.SaveFilePanel` returns an absolute path but `EditorSceneManager.SaveScene` expects a path relative to the Assets folder.

Added a `DialogHelper.SaveFilePanelInProject` which will return a relative path and show the user an error, prompting them to retry, if they specify a path outside of the Assets folder. This behavior is identical to Unity's `EditorUtility.SaveFilePanelInProject` but it allows us to specify a default path that isn't the Assets folder.