### PR TITLE
CommandLine.QuotePath() fixes

### DIFF
--- a/GooglePlayInstant/Editor/AndroidAssetPackagingTool.cs
+++ b/GooglePlayInstant/Editor/AndroidAssetPackagingTool.cs
@@ -71,7 +71,10 @@ namespace GooglePlayInstant.Editor
         /// <returns>An error message if there was a problem running aapt2, or null if successful.</returns>
         public static string Convert(string inputPath, string outputPath)
         {
-            var arguments = string.Format("convert -o {0} --output-format proto {1}", outputPath, inputPath);
+            var arguments = string.Format(
+                "convert -o {0} --output-format proto {1}",
+                CommandLine.QuotePath(outputPath),
+                CommandLine.QuotePath(inputPath));
             var result = CommandLine.Run(GetAapt2Path(), arguments);
             return result.exitCode == 0 ? null : result.message;
         }

--- a/GooglePlayInstant/Editor/ApkSigner.cs
+++ b/GooglePlayInstant/Editor/ApkSigner.cs
@@ -52,8 +52,8 @@ namespace GooglePlayInstant.Editor
         {
             var arguments = string.Format(
                 "-jar {0} verify {1}",
-                CommandLine.QuotePathIfNecessary(GetApkSignerJarPath()),
-                CommandLine.QuotePathIfNecessary(apkPath));
+                CommandLine.QuotePath(GetApkSignerJarPath()),
+                CommandLine.QuotePath(apkPath));
 
             var result = CommandLine.Run(JavaUtilities.JavaBinaryPath, arguments);
             if (result.exitCode == 0)
@@ -130,11 +130,11 @@ namespace GooglePlayInstant.Editor
             // ApkSignerResponder will encode the passwords with UTF8, so we specify "--pass-encoding utf-8" here.
             var arguments = string.Format(
                 "-jar {0} sign --ks {1} --ks-key-alias {2} --pass-encoding utf-8 {3}{4}",
-                CommandLine.QuotePathIfNecessary(GetApkSignerJarPath()),
-                CommandLine.QuotePathIfNecessary(keystoreName),
+                CommandLine.QuotePath(GetApkSignerJarPath()),
+                CommandLine.QuotePath(keystoreName),
                 keyaliasName,
                 additionalArguments,
-                CommandLine.QuotePathIfNecessary(filePath));
+                CommandLine.QuotePath(filePath));
 
             var promptToPasswordDictionary = new Dictionary<string, string>
             {
@@ -157,7 +157,7 @@ namespace GooglePlayInstant.Editor
             }
 
             var newestBuildToolsPath = Path.Combine(AndroidBuildTools.GetBuildToolsPath(), newestBuildToolsVersion);
-            var apkSignerJarPath = Path.Combine(newestBuildToolsPath, "lib/apksigner.jar");
+            var apkSignerJarPath = Path.Combine(newestBuildToolsPath, Path.Combine("lib", "apksigner.jar"));
             if (File.Exists(apkSignerJarPath))
             {
                 return apkSignerJarPath;

--- a/GooglePlayInstant/Editor/Bundletool.cs
+++ b/GooglePlayInstant/Editor/Bundletool.cs
@@ -93,11 +93,12 @@ namespace GooglePlayInstant.Editor
             var bundleConfigJsonFile = Path.Combine(Path.GetTempPath(), "BundleConfig.json");
             File.WriteAllText(bundleConfigJsonFile, BundleConfigJsonText);
 
-            var arguments = string.Format("-jar {0} build-bundle --config={1} --modules={2} --output={3}",
-                GetBundletoolJarPath(),
-                bundleConfigJsonFile,
-                baseModuleZip,
-                outputFile);
+            var arguments = string.Format(
+                "-jar {0} build-bundle --config={1} --modules={2} --output={3}",
+                CommandLine.QuotePath(GetBundletoolJarPath()),
+                CommandLine.QuotePath(bundleConfigJsonFile),
+                CommandLine.QuotePath(baseModuleZip),
+                CommandLine.QuotePath(outputFile));
             var result = CommandLine.Run(JavaUtilities.JavaBinaryPath, arguments);
             return result.exitCode == 0 ? null : result.message;
         }

--- a/GooglePlayInstant/Editor/GooglePlayServices/CommandLine.cs
+++ b/GooglePlayInstant/Editor/GooglePlayServices/CommandLine.cs
@@ -671,11 +671,11 @@ namespace GooglePlayInstant.Editor.GooglePlayServices
         }
 
         /// <summary>
-        /// Returns the specified argument in double quotes if it contains at least one space, otherwise returns as is.
+        /// Returns the specified argument in double quotes.
         /// </summary>
-        public static string QuotePathIfNecessary(string path)
+        public static string QuotePath(string path)
         {
-            return path.Contains(" ") ? string.Format("\"{0}\"", path) : path;
+            return string.Format("\"{0}\"", path);
         }
 
 #if UNITY_EDITOR

--- a/GooglePlayInstant/Editor/PlayInstantRunner.cs
+++ b/GooglePlayInstant/Editor/PlayInstantRunner.cs
@@ -82,8 +82,8 @@ namespace GooglePlayInstant.Editor
                 FileName = JavaUtilities.JavaBinaryPath,
                 Arguments = string.Format(
                     "-jar {0} run {1}",
-                    CommandLine.QuotePathIfNecessary(jarPath),
-                    CommandLine.QuotePathIfNecessary(apkPath))
+                    CommandLine.QuotePath(jarPath),
+                    CommandLine.QuotePath(apkPath))
             };
             window.CommandLineParams.AddEnvironmentVariable(
                 AndroidSdkManager.AndroidHome, AndroidSdkManager.AndroidSdkRoot);

--- a/GooglePlayInstant/Editor/ZipUtils.cs
+++ b/GooglePlayInstant/Editor/ZipUtils.cs
@@ -37,8 +37,8 @@ namespace GooglePlayInstant.Editor
             // Create zip file with options "0" (no per-file compression) and "M" (no JAR manifest file).
             var arguments = string.Format(
                 "c0Mf {0} -C {1} {2}",
-                CommandLine.QuotePathIfNecessary(zipFilePath),
-                CommandLine.QuotePathIfNecessary(inputDirectoryName),
+                CommandLine.QuotePath(zipFilePath),
+                CommandLine.QuotePath(inputDirectoryName),
                 inputFileName);
             var result = CommandLine.Run(JavaUtilities.JarBinaryPath, arguments);
             return result.exitCode == 0 ? null : result.message;
@@ -50,7 +50,7 @@ namespace GooglePlayInstant.Editor
         /// <returns>null if the operation succeeded, or an error message if it failed.</returns>
         public static string UnzipFile(string zipFilePath, string outputDirectoryName)
         {
-            var arguments = string.Format("xf {0}", CommandLine.QuotePathIfNecessary(zipFilePath));
+            var arguments = string.Format("xf {0}", CommandLine.QuotePath(zipFilePath));
             var result = CommandLine.Run(JavaUtilities.JarBinaryPath, arguments, outputDirectoryName);
             return result.exitCode == 0 ? null : result.message;
         }


### PR DESCRIPTION
Add missing double quotes on aapt2 and bundletool.

Consistently wrap double quotes around paths.