### PR TITLE
Miscellaneous QuickDeploy Updates

### DIFF
--- a/GooglePlayInstant/Editor/QuickDeploy/LoadingScreenGenerator.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/LoadingScreenGenerator.cs
@@ -181,7 +181,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         }
 
         /// <summary>
-        /// This returns a texture's size before it's import settings are applied.
+        /// This returns a texture's size before its import settings are applied.
         /// This is useful in cases, for example, where the TextureImporter
         /// rounds an image's size to the nearest power of 2.
         /// </summary>
@@ -194,7 +194,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
                 throw new ArgumentException("The provided texture must be associated with an asset");
             }
 
-            // Load the image from disk then return it's width and height.
+            // Load the image from disk then return its width and height.
             var imageBytes = File.ReadAllBytes(texturePath);
             var tempTexture = new Texture2D(1, 1);
             tempTexture.LoadImage(imageBytes);

--- a/GooglePlayInstant/Editor/QuickDeploy/LoadingScreenGenerator.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/LoadingScreenGenerator.cs
@@ -102,7 +102,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         }
 
         // Visible for testing
-        internal static void PopulateScene(Texture backgroundTexture, string assetBundleUrl)
+        internal static void PopulateScene(Texture2D backgroundTexture, string assetBundleUrl)
         {
             var loadingScreenGameObject = new GameObject("Loading Screen");
 
@@ -153,7 +153,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             return canvasObject;
         }
 
-        private static RawImage GenerateBackground(Texture backgroundTexture)
+        private static RawImage GenerateBackground(Texture2D backgroundTexture)
         {
             var backgroundObject = new GameObject("Background");
 
@@ -173,11 +173,32 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             }
             else
             {
-                backgroundAspectRatioFitter.aspectRatio =
-                    backgroundImage.texture.width / (float) backgroundImage.texture.height;
+                var textureDimensions = GetPreImportTextureDimensions(backgroundTexture);
+                backgroundAspectRatioFitter.aspectRatio = textureDimensions.x / textureDimensions.y;
             }
 
             return backgroundImage;
+        }
+
+        /// <summary>
+        /// This returns a texture's size before it's import settings are applied.
+        /// This is useful in cases, for example, where the TextureImporter
+        /// rounds an image's size to the nearest power of 2.
+        /// </summary>
+        /// <exception cref="ArgumentException">If a texture is provided that isn't associated with an asset. </exception>
+        private static Vector2 GetPreImportTextureDimensions(Texture2D texture)
+        {
+            var texturePath = AssetDatabase.GetAssetPath(texture);
+            if (string.IsNullOrEmpty(texturePath))
+            {
+                throw new ArgumentException("The provided texture must be associated with an asset");
+            }
+
+            // Load the image from disk then return it's width and height.
+            var imageBytes = File.ReadAllBytes(texturePath);
+            var tempTexture = new Texture2D(1, 1);
+            tempTexture.LoadImage(imageBytes);
+            return new Vector2(tempTexture.width, tempTexture.height);
         }
     }
 }

--- a/GooglePlayInstant/Editor/QuickDeploy/LoadingScreenGenerator.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/LoadingScreenGenerator.cs
@@ -31,11 +31,6 @@ namespace GooglePlayInstant.Editor.QuickDeploy
     /// </summary>
     public class LoadingScreenGenerator
     {
-        public const string SceneName = "PlayInstantLoadingScreen.unity";
-
-        public static readonly string SceneDirectoryPath =
-            Path.Combine("Assets", "PlayInstantLoadingScreen");
-
         public static LoadingScreen.LoadingScreen CurrentLoadingScreen { get; private set; }
 
         private const string CanvasName = "Loading Screen Canvas";
@@ -44,8 +39,6 @@ namespace GooglePlayInstant.Editor.QuickDeploy
 
         private const int ReferenceWidth = 1080;
         private const int ReferenceHeight = 1920;
-
-        private static readonly string DefaultSceneFilePath = Path.Combine(SceneDirectoryPath, SceneName);
 
         /// <summary>
         /// Creates a scene in the current project that acts as a loading scene until assetbundles are downloaded from the CDN.
@@ -67,11 +60,8 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             if (!saveOk)
             {
                 // Not a fatal issue. User can attempt to resave this scene.
-                var warningMessage = string.Format("Issue while saving scene {0}.",
-                    SceneName);
-
+                var warningMessage = string.Format("Issue while saving scene {0}.", sceneFilePath);
                 Debug.LogWarning(warningMessage);
-
                 DialogHelper.DisplayMessage(SaveErrorTitle, warningMessage);
             }
             else

--- a/GooglePlayInstant/Editor/QuickDeploy/PlayInstantSceneTreeView.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/PlayInstantSceneTreeView.cs
@@ -29,7 +29,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
     {
         private const int ToggleWidth = 18;
         private int rowID = 0;
-        private readonly List<SceneItem> _allItems = new List<SceneItem>();
+        private List<SceneItem> _allItems = new List<SceneItem>();
 
         public event Action<State> OnTreeStateChanged = delegate { };
 
@@ -88,12 +88,6 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             public bool Enabled;
             public bool OldEnabledValue;
             public string SceneBuildIndexString;
-
-            public override bool Equals(object obj)
-            {
-                var that = obj as SceneItem;
-                return that != null && this.displayName.Equals(that.displayName);
-            }
         }
 
         public void AddOpenScenes()
@@ -120,7 +114,8 @@ namespace GooglePlayInstant.Editor.QuickDeploy
                     Enabled = isSceneEnabled[i]
                 };
 
-                if (!_allItems.Contains(sceneItem))
+                var duplicateItem = _allItems.Find((element) => element.displayName == sceneItem.displayName);
+                if (duplicateItem == null)
                 {
                     _allItems.Add(sceneItem);
                 }
@@ -202,18 +197,27 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             if (args.rowRect.Contains(current.mousePosition) && current.type == EventType.ContextClick)
             {
                 GenericMenu menu = new GenericMenu();
-                menu.AddItem(new GUIContent("Remove Selection"), false, RemoveScene, item);
+                menu.AddItem(new GUIContent("Remove Selection"), false, RemoveSelectedScenes, item);
                 menu.ShowAsContext();
             }
         }
 
-        private void RemoveScene(object item)
+        private void RemoveSelectedScenes(object clickedItem)
         {
-            _allItems.Remove((SceneItem) item);
+            var selectedIds = GetSelection();
+
+            //If nothing is selected, just remove the item that was right-clicked
+            if (selectedIds.Count <= 0)
+            {
+                _allItems.Remove((SceneItem) clickedItem);
+            }
+            else
+            {
+                _allItems = _allItems.Where((item) => !selectedIds.Contains(item.id)).ToList();
+            }
+
             OnRowsChanged();
             Reload();
         }
-
-        //TODO: implement drag and drop
     }
 }

--- a/GooglePlayInstant/Editor/QuickDeploy/PlayInstantSceneTreeView.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/PlayInstantSceneTreeView.cs
@@ -62,22 +62,6 @@ namespace GooglePlayInstant.Editor.QuickDeploy
                 IsSceneEnabled = new bool[0];
                 ViewState = new TreeViewState();
             }
-
-            public override bool Equals(object obj)
-            {
-                var that = obj as State;
-                if (that == null) return false;
-                if (this.ViewState != that.ViewState) return false;
-                if (this.ScenePaths.Length != that.ScenePaths.Length) return false;
-
-                for (int i = 0; i < this.ScenePaths.Length; i++)
-                {
-                    if (this.ScenePaths[i] != that.ScenePaths[i]) return false;
-                    if (this.IsSceneEnabled[i] != that.IsSceneEnabled[i]) return false;
-                }
-
-                return true;
-            }
         }
 
         /// <summary>

--- a/GooglePlayInstant/Editor/QuickDeploy/QuickDeployConfig.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/QuickDeployConfig.cs
@@ -118,8 +118,8 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         public class EditorConfiguration
         {
             public string assetBundleUrl;
-            public string assetBundleFileName;
-            public string loadingSceneFileName;
+            public string assetBundleFileName = Path.Combine("Assets", "MainBundle");
+            public string loadingSceneFileName = Path.Combine("Assets", "PlayInstantLoadingScreen.unity");
             public Texture2D loadingBackgroundImage;
             public PlayInstantSceneTreeView.State assetBundleScenes;
         }

--- a/GooglePlayInstant/Editor/QuickDeploy/QuickDeployWindow.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/QuickDeployWindow.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System;
-using System.IO;
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
@@ -79,6 +78,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             _playInstantSceneTreeTreeView.OnTreeStateChanged += (treeState) =>
             {
                 Config.AssetBundleScenes = treeState;
+                Config.SaveConfiguration(ToolBarSelectedButton.CreateBundle);
             };
         }
 
@@ -194,7 +194,6 @@ namespace GooglePlayInstant.Editor.QuickDeploy
                 HandleBuildAssetBundleButton();
                 HandleDialogExit();
             }
-
             EditorGUILayout.EndHorizontal();
         }
 
@@ -244,6 +243,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         {
             var descriptionTextStyle = CreateDescriptionTextStyle();
 
+            EditorGUI.BeginChangeCheck();
             EditorGUILayout.LabelField("Configure Loading Scene", EditorStyles.boldLabel);
             EditorGUILayout.BeginVertical(UserInputGuiStyle);
             EditorGUILayout.Space();
@@ -270,7 +270,6 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             Config.LoadingBackgroundImage = (Texture2D) EditorGUILayout.ObjectField(Config.LoadingBackgroundImage,
                 typeof(Texture2D), false,
                 GUILayout.MinWidth(FieldMinWidth));
-
             EditorGUILayout.EndHorizontal();
             EditorGUILayout.Space();
             EditorGUILayout.EndVertical();
@@ -279,6 +278,11 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             if (GUILayout.Button("Create Loading Scene..."))
             {
                 HandleCreateLoadingSceneButton();
+            }
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                Config.SaveConfiguration(ToolBarSelectedButton.LoadingScreen);
             }
         }
 

--- a/GooglePlayInstant/Editor/QuickDeploy/QuickDeployWindow.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/QuickDeployWindow.cs
@@ -55,7 +55,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         private const int FieldMinWidth = 100;
         private const int ToolbarHeight = 25;
 
-        // Titles for errors that occur
+        // Titles for errors that occur.
         private const string AssetBundleBuildErrorTitle = "AssetBundle Build Error";
         private const string LoadingScreenCreationErrorTitle = "Loading Screen Creation Error";
 
@@ -78,8 +78,14 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             _playInstantSceneTreeTreeView.OnTreeStateChanged += (treeState) =>
             {
                 Config.AssetBundleScenes = treeState;
-                Config.SaveConfiguration(ToolBarSelectedButton.CreateBundle);
+                Config.SaveConfiguration(true);
             };
+        }
+
+
+        private void Update()
+        {
+            Config.PollForChanges();
         }
 
         private void OnGUI()
@@ -213,7 +219,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
 
             try
             {
-                Config.SaveConfiguration(ToolBarSelectedButton.CreateBundle);
+                Config.SaveConfiguration(true);
                 AssetBundleBuilder.BuildQuickDeployAssetBundle(GetEnabledSceneItemPaths());
             }
             catch (Exception ex)
@@ -282,7 +288,7 @@ namespace GooglePlayInstant.Editor.QuickDeploy
 
             if (EditorGUI.EndChangeCheck())
             {
-                Config.SaveConfiguration(ToolBarSelectedButton.LoadingScreen);
+                Config.SaveConfiguration(false);
             }
         }
 
@@ -305,11 +311,12 @@ namespace GooglePlayInstant.Editor.QuickDeploy
                 // Assume cancelled.
                 return;
             }
+
             Config.LoadingSceneFileName = saveFilePath;
 
             try
             {
-                Config.SaveConfiguration(ToolBarSelectedButton.LoadingScreen);
+                Config.SaveConfiguration(true);
                 LoadingScreenGenerator.GenerateScene(Config.AssetBundleUrl, Config.LoadingBackgroundImage,
                     saveFilePath);
 

--- a/GooglePlayInstant/LoadingScreen/LoadingBar.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingBar.cs
@@ -39,7 +39,7 @@ namespace GooglePlayInstant.LoadingScreen
 
         [Tooltip("Proportion of the loading bar allocated to the asset bundle downloading process. " +
                  "The rest is allocated to installing.")]
-        [Range(0f, 1f)] public float AssetBundleDownloadMaxProportion = .8f;
+        [Range(0f, 1f)] public float AssetBundleDownloadToInstallRatio = 0.8f;
 
         private RectTransform _rectTransform;
 

--- a/GooglePlayInstant/LoadingScreen/LoadingScreen.cs
+++ b/GooglePlayInstant/LoadingScreen/LoadingScreen.cs
@@ -52,7 +52,7 @@ namespace GooglePlayInstant.LoadingScreen
             }
 
             var sceneLoadOperation = SceneManager.LoadSceneAsync(_bundle.GetAllScenePaths()[0]);
-            yield return LoadingBar.FillUntilDone(sceneLoadOperation, LoadingBar.AssetBundleDownloadMaxProportion, 1f);
+            yield return LoadingBar.FillUntilDone(sceneLoadOperation, LoadingBar.AssetBundleDownloadToInstallRatio, 1f);
         }
 
         private IEnumerator GetAssetBundle(string assetBundleUrl)
@@ -61,7 +61,7 @@ namespace GooglePlayInstant.LoadingScreen
             var downloadOperation = StartAssetBundleDownload(assetBundleUrl, out webRequest);
 
             yield return LoadingBar.FillUntilDone(downloadOperation,
-                0f, LoadingBar.AssetBundleDownloadMaxProportion);
+                0f, LoadingBar.AssetBundleDownloadToInstallRatio);
 
             if (IsFailedRequest(webRequest))
             {

--- a/GooglePlayInstant/Tests/Editor/QuickDeploy/ConfigurationTest.cs
+++ b/GooglePlayInstant/Tests/Editor/QuickDeploy/ConfigurationTest.cs
@@ -41,8 +41,7 @@ namespace GooglePlayInstant.Tests.Editor.QuickDeploy
             };
             var inputConfig = new QuickDeployConfig.EditorConfiguration();
 
-            quickDeployConfig.SaveEditorConfiguration(QuickDeployWindow.ToolBarSelectedButton.CreateBundle, inputConfig,
-                TestConfigurationPath);
+            quickDeployConfig.SaveEditorConfiguration(inputConfig, TestConfigurationPath);
 
             var outputConfigurationJson = File.ReadAllText(TestConfigurationPath);
             var outputConfig =
@@ -61,8 +60,7 @@ namespace GooglePlayInstant.Tests.Editor.QuickDeploy
 
             var inputConfig = new QuickDeployConfig.EditorConfiguration();
 
-            quickDeployConfig.SaveEditorConfiguration(QuickDeployWindow.ToolBarSelectedButton.CreateBundle, inputConfig,
-                TestConfigurationPath);
+            quickDeployConfig.SaveEditorConfiguration(inputConfig, TestConfigurationPath);
 
             var outputConfigurationJson = File.ReadAllText(TestConfigurationPath);
             var outputConfig =


### PR DESCRIPTION
- Removed all compiler warnings.
- Fixed issue where selecting multiple scenes and hitting right-click -> Remove Selected, would only remove the item that was right-clicked.
- Fixed issue where most textures by default would have their AspectRatioFitters configured incorrectly when they were used a background in the loading scene.
- Added default file paths for when users save an AssetBundle or a loading scene without a config file.
- Updated the QuickDeployWindow so that it saves its config file whenever the user changes a field. Previously the config file was only saved when the user hit "Build AssetBundle" or "Create Loading Screen"