### PR TITLE
Add app bundle support for pre-2018.3

### DIFF
--- a/GooglePlayInstant/Editor/AndroidAssetPackagingTool.cs
+++ b/GooglePlayInstant/Editor/AndroidAssetPackagingTool.cs
@@ -45,7 +45,7 @@ namespace GooglePlayInstant.Editor
             var newestBuildToolsVersion = AndroidBuildTools.GetNewestBuildToolsVersion();
             if (newestBuildToolsVersion == null)
             {
-                PlayInstantBuilder.LogError(string.Format("Failed to locate {0}", BuildToolsDisplayName));
+                PlayInstantBuilder.DisplayBuildError(string.Format("Failed to locate {0}", BuildToolsDisplayName));
                 return false;
             }
 

--- a/GooglePlayInstant/Editor/AndroidManifest/PostGenerateGradleProjectAndroidManifestUpdater.cs
+++ b/GooglePlayInstant/Editor/AndroidManifest/PostGenerateGradleProjectAndroidManifestUpdater.cs
@@ -16,7 +16,6 @@
 using System;
 using System.IO;
 using System.Xml.Linq;
-using UnityEditor;
 using UnityEditor.Android;
 using UnityEngine;
 
@@ -56,9 +55,8 @@ namespace GooglePlayInstant.Editor.AndroidManifest
             var errorMessage = AndroidManifestHelper.ConvertManifestToInstant(doc, uri);
             if (errorMessage != null)
             {
-                var message = string.Format("Error updating AndroidManifest.xml: {0}", errorMessage);
-                Debug.LogError(message);
-                EditorUtility.DisplayDialog("Build Error", message, "OK");
+                PlayInstantBuilder.DisplayBuildError(
+                    string.Format("Error updating AndroidManifest.xml: {0}", errorMessage));
                 return;
             }
 

--- a/GooglePlayInstant/Editor/AndroidSdkPackageInstaller.cs
+++ b/GooglePlayInstant/Editor/AndroidSdkPackageInstaller.cs
@@ -36,7 +36,8 @@ namespace GooglePlayInstant.Editor
                 "On some systems the install process is slow and does not provide feedback, " +
                 "which may lead you to believe that Unity has frozen or crashed.\n\n" +
                 "Click \"OK\" to continue.";
-            if (!EditorUtility.DisplayDialog("Install Note", message, "OK", "Cancel"))
+            if (!EditorUtility.DisplayDialog(
+                "Install Note", message, WindowUtils.OkButtonText, WindowUtils.CancelButtonText))
             {
                 Debug.LogFormat("Cancelled install of {0}", displayName);
                 return;
@@ -81,7 +82,7 @@ namespace GooglePlayInstant.Editor
         private static void ShowMessage(string message)
         {
             Debug.LogFormat("AndroidSdkPackageInstaller: {0}", message);
-            EditorUtility.DisplayDialog("Android SDK Package Installer", message, "OK");
+            EditorUtility.DisplayDialog("Android SDK Package Installer", message, WindowUtils.OkButtonText);
         }
     }
 }

--- a/GooglePlayInstant/Editor/AppBundleBuilder.cs
+++ b/GooglePlayInstant/Editor/AppBundleBuilder.cs
@@ -46,7 +46,10 @@ namespace GooglePlayInstant.Editor
             {
                 DisplayProgress("Running aapt2", 0.2f);
                 var workingDirectory = new DirectoryInfo(Path.Combine(Path.GetTempPath(), "play-instant-unity"));
-                workingDirectory.Delete(true);
+                if (workingDirectory.Exists)
+                {
+                    workingDirectory.Delete(true);
+                }
 
                 workingDirectory.Create();
                 var sourceDirectoryInfo = workingDirectory.CreateSubdirectory("source");

--- a/GooglePlayInstant/Editor/AppBundleBuilder.cs
+++ b/GooglePlayInstant/Editor/AppBundleBuilder.cs
@@ -60,7 +60,7 @@ namespace GooglePlayInstant.Editor
                 var aaptResult = AndroidAssetPackagingTool.Convert(binaryFormatFilePath, protoFormatFilePath);
                 if (aaptResult != null)
                 {
-                    LogError("aapt2", aaptResult);
+                    DisplayBuildError("aapt2", aaptResult);
                     return;
                 }
 
@@ -68,7 +68,7 @@ namespace GooglePlayInstant.Editor
                 var unzipFileResult = ZipUtils.UnzipFile(protoFormatFileName, sourceDirectoryInfo.FullName);
                 if (unzipFileResult != null)
                 {
-                    LogError("Unzip", unzipFileResult);
+                    DisplayBuildError("Unzip", unzipFileResult);
                     return;
                 }
 
@@ -80,7 +80,7 @@ namespace GooglePlayInstant.Editor
                 var zipFileResult = ZipUtils.CreateZipFile(baseModuleZip, destinationDirectoryInfo.FullName, ".");
                 if (zipFileResult != null)
                 {
-                    LogError("Zip creation", zipFileResult);
+                    DisplayBuildError("Zip creation", zipFileResult);
                     return;
                 }
 
@@ -92,7 +92,7 @@ namespace GooglePlayInstant.Editor
                 var buildBundleResult = Bundletool.BuildBundle(baseModuleZip, aabFilePath);
                 if (buildBundleResult != null)
                 {
-                    LogError("bundletool", buildBundleResult);
+                    DisplayBuildError("bundletool", buildBundleResult);
                     return;
                 }
 
@@ -100,7 +100,7 @@ namespace GooglePlayInstant.Editor
                 var signingResult = ApkSigner.SignZip(aabFilePath);
                 if (signingResult != null)
                 {
-                    LogError("Signing", signingResult);
+                    DisplayBuildError("Signing", signingResult);
                     return;
                 }
             }
@@ -124,7 +124,7 @@ namespace GooglePlayInstant.Editor
             }
         }
 
-        private static void LogError(string errorType, string errorMessage)
+        private static void DisplayBuildError(string errorType, string errorMessage)
         {
             if (!WindowUtils.IsHeadlessMode())
             {

--- a/GooglePlayInstant/Editor/AppBundleBuilder.cs
+++ b/GooglePlayInstant/Editor/AppBundleBuilder.cs
@@ -1,0 +1,202 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace GooglePlayInstant.Editor
+{
+    /// <summary>
+    /// Helper to build an Android App Bundle file on Unity version 2018.2 and earlier.
+    /// </summary>
+    public static class AppBundleBuilder
+    {
+        private const string BaseModuleZipFileName = "base.zip";
+
+        public static void Build(string aabFilePath)
+        {
+            var tempFilePath = Path.GetTempFileName();
+            Debug.LogFormat("Building Package: {0}", tempFilePath);
+            var buildPlayerOptions = PlayInstantBuilder.CreateBuildPlayerOptions(tempFilePath, BuildOptions.None);
+
+            // Do not use BuildAndSign since this signature won't be used.
+            if (!PlayInstantBuilder.Build(buildPlayerOptions))
+            {
+                // Do not log here. The method we called was responsible for logging.
+                return;
+            }
+
+            CreateAppBundle(tempFilePath, aabFilePath);
+        }
+
+        // TODO: currently all processing is synchronous; consider moving to a separate thread
+        private static void CreateAppBundle(string inputFile, string aabFilePath)
+        {
+            try
+            {
+                DisplayProgress("Running aapt2", 0.2f);
+                var workingDirectory = new DirectoryInfo(Path.Combine(Path.GetTempPath(), "play-instant-unity"));
+                if (workingDirectory.Exists)
+                {
+                    workingDirectory.Delete(true);
+                }
+
+                workingDirectory.Create();
+                var sourceDirectoryInfo = workingDirectory.CreateSubdirectory("source");
+                var destinationDirectoryInfo = workingDirectory.CreateSubdirectory("destination");
+
+                var tempFileName = Path.GetRandomFileName();
+                var tempFilePath = Path.Combine(sourceDirectoryInfo.FullName, tempFileName);
+                var aaptResult = AndroidAssetPackagingTool.Convert(inputFile, tempFilePath);
+                if (aaptResult != null)
+                {
+                    LogError("aapt2", aaptResult);
+                    return;
+                }
+
+                DisplayProgress("Creating base module", 0.4f);
+                var unzipFileResult = ZipUtils.UnzipFile(tempFileName, sourceDirectoryInfo.FullName);
+                if (unzipFileResult != null)
+                {
+                    LogError("Unzip", unzipFileResult);
+                    return;
+                }
+
+                File.Delete(tempFilePath);
+
+                var baseModuleZip = Path.Combine(workingDirectory.FullName, BaseModuleZipFileName);
+                ConvertFiles(sourceDirectoryInfo, destinationDirectoryInfo);
+
+                var zipFileResult = ZipUtils.CreateZipFile(baseModuleZip, destinationDirectoryInfo.FullName, ".");
+                if (zipFileResult != null)
+                {
+                    LogError("Zip creation", zipFileResult);
+                    return;
+                }
+
+                DisplayProgress("Running bundletool", 0.6f);
+                var buildBundleResult = Bundletool.BuildBundle(baseModuleZip, aabFilePath);
+                if (buildBundleResult != null)
+                {
+                    LogError("bundletool", buildBundleResult);
+                    return;
+                }
+
+                DisplayProgress("Signing bundle", 0.8f);
+                var signingResult = ApkSigner.SignZip(aabFilePath);
+                if (signingResult != null)
+                {
+                    LogError("Signing", signingResult);
+                    return;
+                }
+            }
+            finally
+            {
+                if (!PlayInstantBuilder.IsHeadlessMode())
+                {
+                    EditorUtility.ClearProgressBar();
+                }
+            }
+
+            Debug.LogFormat("Finished building app bundle: {0}", aabFilePath);
+        }
+
+        private static void DisplayProgress(string info, float progress)
+        {
+            Debug.LogFormat("{0}...", info);
+            if (!PlayInstantBuilder.IsHeadlessMode())
+            {
+                EditorUtility.DisplayProgressBar("Building App Bundle", info, progress);
+            }
+        }
+
+        private static void LogError(string errorType, string errorMessage)
+        {
+            if (!PlayInstantBuilder.IsHeadlessMode())
+            {
+                EditorUtility.ClearProgressBar();
+            }
+
+            PlayInstantBuilder.LogError(string.Format("{0} failed: {1}", errorType, errorMessage));
+        }
+
+        private static void ConvertFiles(DirectoryInfo source, DirectoryInfo destination)
+        {
+            // Copy files in the root directory.
+            foreach (var fileInfo in source.GetFiles())
+            {
+                var fileName = fileInfo.Name;
+                if (fileName == "AndroidManifest.xml")
+                {
+                    var subdirectory = destination.CreateSubdirectory("manifest");
+                    fileInfo.CopyTo(Path.Combine(subdirectory.FullName, fileName));
+                }
+                else if (fileName == "resources.pb")
+                {
+                    fileInfo.CopyTo(Path.Combine(destination.FullName, fileName));
+                }
+                else if (fileName.EndsWith("dex"))
+                {
+                    var subdirectory = destination.CreateSubdirectory("dex");
+                    fileInfo.CopyTo(Path.Combine(subdirectory.FullName, fileName));
+                }
+                else
+                {
+                    var subdirectory = destination.CreateSubdirectory("root");
+                    fileInfo.CopyTo(Path.Combine(subdirectory.FullName, fileName));
+                }
+            }
+
+            // Copy all other files.
+            foreach (var directoryInfo in source.GetDirectories())
+            {
+                var directoryName = directoryInfo.Name;
+                switch (directoryName)
+                {
+                    case "META-INF":
+                        // Skip files like MANIFEST.MF
+                        break;
+                    case "assets":
+                    case "lib":
+                    case "res":
+                        CopyDirectory(directoryInfo, destination.CreateSubdirectory(directoryName));
+                        break;
+                    default:
+                        var subdirectory = destination.CreateSubdirectory("root");
+                        CopyDirectory(directoryInfo, subdirectory.CreateSubdirectory(directoryName));
+                        break;
+                }
+            }
+        }
+
+        private static void CopyDirectory(DirectoryInfo source, DirectoryInfo destination)
+        {
+            if (!destination.Exists)
+            {
+                destination.Create();
+            }
+
+            foreach (var fileInfo in source.GetFiles())
+            {
+                fileInfo.CopyTo(Path.Combine(destination.FullName, fileInfo.Name));
+            }
+
+            foreach (var subdirectoryInfo in source.GetDirectories())
+            {
+                CopyDirectory(subdirectoryInfo, destination.CreateSubdirectory(subdirectoryInfo.Name));
+            }
+        }
+    }
+}

--- a/GooglePlayInstant/Editor/AppBundlePublisher.cs
+++ b/GooglePlayInstant/Editor/AppBundlePublisher.cs
@@ -12,26 +12,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if UNITY_2018_3_OR_NEWER
 using UnityEditor;
 using UnityEngine;
-#else
-using System;
-#endif
 
 namespace GooglePlayInstant.Editor
 {
     /// <summary>
-    /// Helper to build an Android App Bundle file suitable for publishing on Play Console.
+    /// Helper to build <a href="https://developer.android.com/platform/technology/app-bundle/">Android App Bundle</a>
+    /// files suitable for publishing on Play Console.
     /// </summary>
     public static class AppBundlePublisher
     {
         /// <summary>
-        /// Builds an Android App Bundle.
+        /// Builds an Android App Bundle at a user-specified file location.
         /// </summary>
         public static void Build()
         {
-#if UNITY_2018_3_OR_NEWER
+#if !UNITY_2018_3_OR_NEWER
+            if (!AndroidAssetPackagingTool.CheckConvert())
+            {
+                return;
+            }
+
+            if (!Bundletool.CheckBundletool())
+            {
+                return;
+            }
+#endif
+
+            // TODO: add checks for preferred Scripting Backend and Target Architectures.
+
             var aabFilePath = EditorUtility.SaveFilePanel("Create Android App Bundle", null, null, "aab");
             if (string.IsNullOrEmpty(aabFilePath))
             {
@@ -39,7 +49,17 @@ namespace GooglePlayInstant.Editor
                 return;
             }
 
+            Build(aabFilePath);
+        }
+
+        /// <summary>
+        /// Builds an Android App Bundle at the specified location. Assumes that all dependencies (e.g. aapt)
+        /// are already in-place.
+        /// </summary>
+        public static void Build(string aabFilePath)
+        {
             Debug.LogFormat("Building app bundle: {0}", aabFilePath);
+#if UNITY_2018_3_OR_NEWER
             EditorUserBuildSettings.buildAppBundle = true;
             var buildPlayerOptions = PlayInstantBuilder.CreateBuildPlayerOptions(aabFilePath, BuildOptions.None);
             if (PlayInstantBuilder.Build(buildPlayerOptions))
@@ -48,7 +68,7 @@ namespace GooglePlayInstant.Editor
                 Debug.LogFormat("Finished building app bundle: {0}", aabFilePath);
             }
 #else
-            throw new InvalidOperationException("Android App Bundles are only supported on Unity 2018.3+");
+            AppBundleBuilder.Build(aabFilePath);
 #endif
         }
     }

--- a/GooglePlayInstant/Editor/BuildSettingsWindow.cs
+++ b/GooglePlayInstant/Editor/BuildSettingsWindow.cs
@@ -202,7 +202,7 @@ namespace GooglePlayInstant.Editor
             {
                 var message = string.Format("Error updating AndroidManifest.xml: {0}", errorMessage);
                 Debug.LogError(message);
-                EditorUtility.DisplayDialog("Error Saving", message, "OK");
+                EditorUtility.DisplayDialog("Error Saving", message, WindowUtils.OkButtonText);
                 return;
             }
 
@@ -234,7 +234,7 @@ namespace GooglePlayInstant.Editor
         private static void DisplayUrlError(string message)
         {
             Debug.LogError(message);
-            EditorUtility.DisplayDialog("Invalid Default URL", message, "OK");
+            EditorUtility.DisplayDialog("Invalid Default URL", message, WindowUtils.OkButtonText);
         }
     }
 }

--- a/GooglePlayInstant/Editor/BundletoolDownloadWindow.cs
+++ b/GooglePlayInstant/Editor/BundletoolDownloadWindow.cs
@@ -76,7 +76,9 @@ namespace GooglePlayInstant.Editor
 
                     Debug.LogErrorFormat("Bundletool download error: {0}", downloadRequestError);
                     if (EditorUtility.DisplayDialog("Download Failed",
-                        downloadRequestError + "\n\nClick \"OK\" to retry.", "OK", "Cancel"))
+                        string.Format("{0}\n\nClick \"{1}\" to retry.", downloadRequestError, WindowUtils.OkButtonText),
+                        WindowUtils.OkButtonText,
+                        WindowUtils.CancelButtonText))
                     {
                         StartDownload();
                     }
@@ -99,7 +101,7 @@ namespace GooglePlayInstant.Editor
                 Debug.LogFormat("Bundletool downloaded: {0}", bundletoolJarPath);
                 var message = string.Format(
                     "Bundletool has been downloaded to your project's \"Library\" directory: {0}", bundletoolJarPath);
-                if (EditorUtility.DisplayDialog("Download Complete", message, "OK"))
+                if (EditorUtility.DisplayDialog("Download Complete", message, WindowUtils.OkButtonText))
                 {
                     Close();
                 }

--- a/GooglePlayInstant/Editor/PlayInstantBuilder.cs
+++ b/GooglePlayInstant/Editor/PlayInstantBuilder.cs
@@ -222,7 +222,10 @@ namespace GooglePlayInstant.Editor
             }
         }
 
-        private static bool IsHeadlessMode()
+        /// <summary>
+        /// Returns true if this is a headless command line build, and false if it is an Editor-initiated build.
+        /// </summary>
+        public static bool IsHeadlessMode()
         {
             return SystemInfo.graphicsDeviceType == UnityEngine.Rendering.GraphicsDeviceType.Null;
         }

--- a/GooglePlayInstant/Editor/PlayInstantBuilder.cs
+++ b/GooglePlayInstant/Editor/PlayInstantBuilder.cs
@@ -82,8 +82,8 @@ namespace GooglePlayInstant.Editor
             // ApkSigner is fast so we call it synchronously rather than wait for the post build AppDomain reset.
             if (!ApkSigner.IsAvailable())
             {
-                LogError("Unable to locate apksigner. Check that a recent version of Android SDK Build-Tools " +
-                         "is installed and check the Console log for more details on the error.");
+                DisplayBuildError("Unable to locate apksigner. Check that a recent version of Android SDK " +
+                         "Build-Tools is installed and check the Console log for more details on the error.");
                 return false;
             }
 
@@ -102,7 +102,7 @@ namespace GooglePlayInstant.Editor
                 return true;
             }
 
-            LogError(string.Format("Failed to re-sign the APK using apksigner:\n\n{0}", signingResult));
+            DisplayBuildError(string.Format("Failed to re-sign the APK using apksigner:\n\n{0}", signingResult));
             return false;
 #endif
         }
@@ -184,7 +184,7 @@ namespace GooglePlayInstant.Editor
             }
             else
             {
-                LogError(buildReport);
+                DisplayBuildError(buildReport);
             }
 
             return false;

--- a/GooglePlayInstant/Editor/PlayInstantBuilder.cs
+++ b/GooglePlayInstant/Editor/PlayInstantBuilder.cs
@@ -28,8 +28,6 @@ namespace GooglePlayInstant.Editor
     public static class PlayInstantBuilder
     {
         private const string BuildErrorTitle = "Build Error";
-        private const string OkButtonText = "OK";
-        private const string CancelButtonText = "Cancel";
 
         /// <summary>
         /// Returns an array of enabled scenes from the "Scenes In Build" section of Unity's Build Settings window.
@@ -121,8 +119,8 @@ namespace GooglePlayInstant.Editor
                 Debug.LogError("Build halted since selected build type is \"Installed\"");
                 var message = string.Format(
                     "The currently selected Android build type is \"Installed\".\n\n" +
-                    "Click \"OK\" to open the \"{0}\" window where the build type can be changed to \"Instant\".",
-                    BuildSettingsWindow.WindowTitle);
+                    "Click \"{0}\" to open the \"{1}\" window where the build type can be changed to \"Instant\".",
+                    WindowUtils.OkButtonText, BuildSettingsWindow.WindowTitle);
                 if (DisplayBuildErrorDialog(message))
                 {
                     BuildSettingsWindow.ShowWindow();
@@ -139,8 +137,8 @@ namespace GooglePlayInstant.Editor
                 Debug.LogErrorFormat("Build halted due to incompatible settings: {0}",
                     string.Join(", ", failedPolicies.ToArray()));
                 var message = string.Format(
-                    "{0}\n\nClick \"OK\" to open the settings window and make required changes.",
-                    string.Join("\n\n", failedPolicies.ToArray()));
+                    "{0}\n\nClick \"{1}\" to open the settings window and make required changes.",
+                    string.Join("\n\n", failedPolicies.ToArray()), WindowUtils.OkButtonText);
                 if (DisplayBuildErrorDialog(message))
                 {
                     PlayerSettingsWindow.ShowWindow();
@@ -167,10 +165,10 @@ namespace GooglePlayInstant.Editor
                     // Actual success.
                     return true;
                 case BuildResult.Failed:
-                    LogError(string.Format("Build failed with {0} error(s)", buildReport.summary.totalErrors));
+                    DisplayBuildError(string.Format("Build failed with {0} error(s)", buildReport.summary.totalErrors));
                     return false;
                 default:
-                    LogError("Build failed with unknown error");
+                    DisplayBuildError("Build failed with unknown error");
                     return false;
             }
 #else
@@ -200,34 +198,27 @@ namespace GooglePlayInstant.Editor
         /// <returns>True if the user clicks "OK", otherwise false.</returns>
         public static bool DisplayBuildErrorDialog(string message)
         {
-            if (IsHeadlessMode())
+            if (WindowUtils.IsHeadlessMode())
             {
                 // During a headless build it isn't possible to prompt to fix the issue, so always return false.
                 Debug.LogErrorFormat("Build error in headless mode: {0}", message);
                 return false;
             }
-            return EditorUtility.DisplayDialog(BuildErrorTitle, message, OkButtonText, CancelButtonText);
+            return EditorUtility.DisplayDialog(
+                BuildErrorTitle, message, WindowUtils.OkButtonText, WindowUtils.CancelButtonText);
         }
 
         /// <summary>
         /// Displays the specified message indicating that a build error occurred.
         /// </summary>
-        public static void LogError(string message)
+        public static void DisplayBuildError(string message)
         {
             Debug.LogErrorFormat("Build error: {0}", message);
 
-            if (!IsHeadlessMode())
+            if (!WindowUtils.IsHeadlessMode())
             {
-                EditorUtility.DisplayDialog(BuildErrorTitle, message, OkButtonText);
+                EditorUtility.DisplayDialog(BuildErrorTitle, message, WindowUtils.OkButtonText);
             }
-        }
-
-        /// <summary>
-        /// Returns true if this is a headless command line build, and false if it is an Editor-initiated build.
-        /// </summary>
-        public static bool IsHeadlessMode()
-        {
-            return SystemInfo.graphicsDeviceType == UnityEngine.Rendering.GraphicsDeviceType.Null;
         }
     }
 }

--- a/GooglePlayInstant/Editor/PlayInstantEditorMenu.cs
+++ b/GooglePlayInstant/Editor/PlayInstantEditorMenu.cs
@@ -71,11 +71,13 @@ namespace GooglePlayInstant.Editor
             PlayInstantRunner.InstallPlayInstantSdk();
         }
 
+#if UNITY_2018_3_OR_NEWER
         [MenuItem("PlayInstant/Build Android App Bundle...", false, 300)]
         private static void BuildAndroidAppBundle()
         {
             AppBundlePublisher.Build();
         }
+#endif
 
         [MenuItem("PlayInstant/Build for Play Console...", false, 301)]
         private static void BuildForPlayConsole()

--- a/GooglePlayInstant/Editor/PlayInstantEditorMenu.cs
+++ b/GooglePlayInstant/Editor/PlayInstantEditorMenu.cs
@@ -71,13 +71,11 @@ namespace GooglePlayInstant.Editor
             PlayInstantRunner.InstallPlayInstantSdk();
         }
 
-#if UNITY_2018_3_OR_NEWER
         [MenuItem("PlayInstant/Build Android App Bundle...", false, 300)]
         private static void BuildAndroidAppBundle()
         {
             AppBundlePublisher.Build();
         }
-#endif
 
         [MenuItem("PlayInstant/Build for Play Console...", false, 301)]
         private static void BuildForPlayConsole()

--- a/GooglePlayInstant/Editor/PlayInstantPublisher.cs
+++ b/GooglePlayInstant/Editor/PlayInstantPublisher.cs
@@ -59,7 +59,7 @@ namespace GooglePlayInstant.Editor
             }
             else
             {
-                PlayInstantBuilder.LogError(string.Format("Zip creation failed: {0}", zipFileResult));
+                PlayInstantBuilder.DisplayBuildError(string.Format("Zip creation failed: {0}", zipFileResult));
             }
         }
     }

--- a/GooglePlayInstant/Editor/PlayInstantRunner.cs
+++ b/GooglePlayInstant/Editor/PlayInstantRunner.cs
@@ -36,7 +36,7 @@ namespace GooglePlayInstant.Editor
         {
             if (!Directory.Exists(AndroidSdkManager.AndroidSdkRoot))
             {
-                PlayInstantBuilder.LogError(
+                PlayInstantBuilder.DisplayBuildError(
                     "Failed to locate the Android SDK. Check Preferences -> External Tools to set the path.");
                 return;
             }

--- a/GooglePlayInstant/Editor/PlayerSettingsWindow.cs
+++ b/GooglePlayInstant/Editor/PlayerSettingsWindow.cs
@@ -72,7 +72,8 @@ namespace GooglePlayInstant.Editor
                         else
                         {
                             Debug.LogErrorFormat("Failed to update setting: {0}", policy.Name);
-                            EditorUtility.DisplayDialog("Error updating", "Failed to update setting", "OK");
+                            EditorUtility.DisplayDialog(
+                                "Error updating", "Failed to update setting", WindowUtils.OkButtonText);
                         }
 
                         Repaint();

--- a/GooglePlayInstant/Editor/WindowUtils.cs
+++ b/GooglePlayInstant/Editor/WindowUtils.cs
@@ -23,8 +23,15 @@ namespace GooglePlayInstant.Editor
     /// </summary>
     public static class WindowUtils
     {
+        public const string OkButtonText = "OK";
+        public const string CancelButtonText = "Cancel";
+
         private const float ShortButtonWidth = 100.0f;
 
+        /// <summary>
+        /// Creates a right-aligned fixed-width button with the specified button text. If the button is clicked,
+        /// the specified action will be invoked.
+        /// </summary>
         public static void CreateRightAlignedButton(string text, Action action)
         {
             EditorGUILayout.BeginHorizontal();
@@ -35,6 +42,15 @@ namespace GooglePlayInstant.Editor
             }
 
             EditorGUILayout.EndHorizontal();
+        }
+
+        /// <summary>
+        /// Returns true if the running instance of Unity is headless (e.g. a command line build),
+        /// and false if it's a normal instance of Unity.
+        /// </summary>
+        public static bool IsHeadlessMode()
+        {
+            return SystemInfo.graphicsDeviceType == UnityEngine.Rendering.GraphicsDeviceType.Null;
         }
     }
 }

--- a/GooglePlayInstant/Samples/TestApp/Editor/TestAppBuilder.cs
+++ b/GooglePlayInstant/Samples/TestApp/Editor/TestAppBuilder.cs
@@ -50,7 +50,11 @@ namespace GooglePlayInstant.Samples.TestApp.Editor
             var requiredPolicies = PlayInstantSettingPolicy.GetRequiredPolicies();
             foreach (var policy in requiredPolicies)
             {
-                policy.ChangeState();
+                var policyChangeCompleted = policy.ChangeState();
+                if (!policyChangeCompleted)
+                {
+                    throw new Exception(string.Format("Failed to change policy: {0}", policy.Name));
+                }
             }
 
             SetTargetArchitectures();


### PR DESCRIPTION
Call bundletool to build an Android App Bundle on Unity 5.6+.

Update TestAppBuilder to also generate a testapp.aab file.