### PR TITLE
Check the project for an icon during publish builds

### DIFF
--- a/GooglePlayInstant/Editor/AppBundlePublisher.cs
+++ b/GooglePlayInstant/Editor/AppBundlePublisher.cs
@@ -40,6 +40,11 @@ namespace GooglePlayInstant.Editor
             }
 #endif
 
+            if (!PlayInstantBuilder.CheckBuildAndPublishPrerequisites())
+            {
+                return;
+            }
+
             // TODO: add checks for preferred Scripting Backend and Target Architectures.
 
             var aabFilePath = EditorUtility.SaveFilePanel("Create Android App Bundle", null, null, "aab");
@@ -53,8 +58,8 @@ namespace GooglePlayInstant.Editor
         }
 
         /// <summary>
-        /// Builds an Android App Bundle at the specified location. Assumes that all dependencies (e.g. aapt)
-        /// are already in-place.
+        /// Builds an Android App Bundle at the specified location. Assumes that all dependencies are already in-place,
+        /// e.g. aapt2 and bundletool.
         /// </summary>
         public static void Build(string aabFilePath)
         {

--- a/GooglePlayInstant/Editor/PlayInstantBuilder.cs
+++ b/GooglePlayInstant/Editor/PlayInstantBuilder.cs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using GooglePlayInstant.Editor.GooglePlayServices;
 using UnityEditor;
 using UnityEngine;
 #if UNITY_2018_1_OR_NEWER
@@ -28,6 +30,102 @@ namespace GooglePlayInstant.Editor
     public static class PlayInstantBuilder
     {
         private const string BuildErrorTitle = "Build Error";
+
+        /// <summary>
+        /// Displays an error or warning dialog if there is an issue that would prevent a build from succeeding.
+        /// This method performs the checks from <see cref="CheckBuildPrerequisites"/>, but also performs checks
+        /// relevant to builds intended for publishing on Play Console.
+        /// </summary>
+        /// <returns>True if all prerequisites are met, or false if one failed.</returns>
+        public static bool CheckBuildAndPublishPrerequisites()
+        {
+            if (!CheckBuildPrerequisites())
+            {
+                return false;
+            }
+
+            // This is a warning that can be skipped, so it should be checked last.
+            // BuildTargetGroup.Unknown is used when checking the project's "Default Icon".
+            if (!HasIconForTargetGroup(BuildTargetGroup.Unknown) && !HasIconForTargetGroup(BuildTargetGroup.Android))
+            {
+                if (WindowUtils.IsHeadlessMode())
+                {
+                    Debug.LogError("Build failure: the project is missing an application icon.");
+                    return false;
+                }
+
+                var message = "Failed to locate a Default Icon or an Android Icon for this project. Prior to " +
+                              "publishing it's strongly recommended that the project have a custom icon, or " +
+                              "devices running Android Oreo or later will display the Unity application icon.\n\n" +
+                              "Click \"Continue\" to continue with the build, or \"Cancel\" to abort the build.";
+                if (!EditorUtility.DisplayDialog("Build Warning", message, "Continue", WindowUtils.CancelButtonText))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Displays an error dialog if there is an issue that would prevent a build from succeeding.
+        /// </summary>
+        /// <returns>True if all prerequisites are met, or false if one failed.</returns>
+        public static bool CheckBuildPrerequisites()
+        {
+            if (!Directory.Exists(AndroidSdkManager.AndroidSdkRoot))
+            {
+                DisplayBuildError(
+                    "Failed to locate the Android SDK. Check Preferences -> External Tools to set the path.");
+                return false;
+            }
+
+            try
+            {
+                var ignored = JavaUtilities.JavaBinaryPath;
+            }
+            catch (JavaUtilities.ToolNotFoundException)
+            {
+                DisplayBuildError(
+                    "Failed to locate the Java JDK. Check Preferences -> External Tools to set the path.");
+                return false;
+            }
+
+            if (!PlayInstantBuildConfiguration.IsInstantBuildType())
+            {
+                Debug.LogError("Build halted since selected build type is \"Installed\"");
+                var message = string.Format(
+                    "The currently selected Android build type is \"Installed\".\n\n" +
+                    "Click \"{0}\" to open the \"{1}\" window where the build type can be changed to \"Instant\".",
+                    WindowUtils.OkButtonText, BuildSettingsWindow.WindowTitle);
+                if (DisplayBuildErrorDialog(message))
+                {
+                    BuildSettingsWindow.ShowWindow();
+                }
+
+                return false;
+            }
+
+            var failedPolicies = new List<string>(PlayInstantSettingPolicy.GetRequiredPolicies()
+                .Where(policy => !policy.IsCorrectState())
+                .Select(policy => policy.Name));
+            if (failedPolicies.Count > 0)
+            {
+                Debug.LogErrorFormat("Build halted due to incompatible settings: {0}",
+                    string.Join(", ", failedPolicies.ToArray()));
+                var message = string.Format(
+                    "{0}\n\nClick \"{1}\" to open the settings window and make required changes.",
+                    string.Join("\n\n", failedPolicies.ToArray()), WindowUtils.OkButtonText);
+                if (DisplayBuildErrorDialog(message))
+                {
+                    PlayerSettingsWindow.ShowWindow();
+                }
+
+                return false;
+            }
+
+            return true;
+        }
 
         /// <summary>
         /// Returns an array of enabled scenes from the "Scenes In Build" section of Unity's Build Settings window.
@@ -83,7 +181,7 @@ namespace GooglePlayInstant.Editor
             if (!ApkSigner.IsAvailable())
             {
                 DisplayBuildError("Unable to locate apksigner. Check that a recent version of Android SDK " +
-                         "Build-Tools is installed and check the Console log for more details on the error.");
+                                  "Build-Tools is installed and check the Console log for more details on the error.");
                 return false;
             }
 
@@ -114,39 +212,6 @@ namespace GooglePlayInstant.Editor
         /// <returns>True if the build succeeded, false if it failed or was cancelled.</returns>
         public static bool Build(BuildPlayerOptions buildPlayerOptions)
         {
-            if (!PlayInstantBuildConfiguration.IsInstantBuildType())
-            {
-                Debug.LogError("Build halted since selected build type is \"Installed\"");
-                var message = string.Format(
-                    "The currently selected Android build type is \"Installed\".\n\n" +
-                    "Click \"{0}\" to open the \"{1}\" window where the build type can be changed to \"Instant\".",
-                    WindowUtils.OkButtonText, BuildSettingsWindow.WindowTitle);
-                if (DisplayBuildErrorDialog(message))
-                {
-                    BuildSettingsWindow.ShowWindow();
-                }
-
-                return false;
-            }
-
-            var failedPolicies = new List<string>(PlayInstantSettingPolicy.GetRequiredPolicies()
-                .Where(policy => !policy.IsCorrectState())
-                .Select(policy => policy.Name));
-            if (failedPolicies.Count > 0)
-            {
-                Debug.LogErrorFormat("Build halted due to incompatible settings: {0}",
-                    string.Join(", ", failedPolicies.ToArray()));
-                var message = string.Format(
-                    "{0}\n\nClick \"{1}\" to open the settings window and make required changes.",
-                    string.Join("\n\n", failedPolicies.ToArray()), WindowUtils.OkButtonText);
-                if (DisplayBuildErrorDialog(message))
-                {
-                    PlayerSettingsWindow.ShowWindow();
-                }
-
-                return false;
-            }
-
             var buildReport = BuildPipeline.BuildPlayer(buildPlayerOptions);
 #if UNITY_2018_1_OR_NEWER
             switch (buildReport.summary.result)
@@ -204,6 +269,7 @@ namespace GooglePlayInstant.Editor
                 Debug.LogErrorFormat("Build error in headless mode: {0}", message);
                 return false;
             }
+
             return EditorUtility.DisplayDialog(
                 BuildErrorTitle, message, WindowUtils.OkButtonText, WindowUtils.CancelButtonText);
         }
@@ -219,6 +285,12 @@ namespace GooglePlayInstant.Editor
             {
                 EditorUtility.DisplayDialog(BuildErrorTitle, message, WindowUtils.OkButtonText);
             }
+        }
+
+        private static bool HasIconForTargetGroup(BuildTargetGroup buildTargetGroup)
+        {
+            var icons = PlayerSettings.GetIconsForTargetGroup(buildTargetGroup);
+            return icons != null && icons.Any(icon => icon != null);
         }
     }
 }

--- a/GooglePlayInstant/Editor/PlayInstantPublisher.cs
+++ b/GooglePlayInstant/Editor/PlayInstantPublisher.cs
@@ -30,6 +30,11 @@ namespace GooglePlayInstant.Editor
         /// </summary>
         public static void Build()
         {
+            if (!PlayInstantBuilder.CheckBuildAndPublishPrerequisites())
+            {
+                return;
+            }
+
             var zipFilePath = EditorUtility.SaveFilePanel("Create APK in ZIP File", null, null, "zip");
             if (string.IsNullOrEmpty(zipFilePath))
             {

--- a/GooglePlayInstant/Editor/PlayInstantRunner.cs
+++ b/GooglePlayInstant/Editor/PlayInstantRunner.cs
@@ -34,10 +34,8 @@ namespace GooglePlayInstant.Editor
         /// </summary>
         public static void BuildAndRun()
         {
-            if (!Directory.Exists(AndroidSdkManager.AndroidSdkRoot))
+            if (!PlayInstantBuilder.CheckBuildPrerequisites())
             {
-                PlayInstantBuilder.DisplayBuildError(
-                    "Failed to locate the Android SDK. Check Preferences -> External Tools to set the path.");
                 return;
             }
 


### PR DESCRIPTION
On Android versions prior to Oreo, the instant app icon isn't shown
anywhere, so some Unity apps are being uploaded without one. However,
on Oreo and later devices the icon is used, so display a warning when
performing a publish build without an icon.

Also rearrange some of the build prerequisite checks for easier reuse.
Also display publish build errors prior to showing the "Save" dialog.