### PR TITLE
Include plugin version in manifest of instant builds

### DIFF
--- a/GooglePlayInstant/Editor/AndroidManifest/IAndroidManifestUpdater.cs
+++ b/GooglePlayInstant/Editor/AndroidManifest/IAndroidManifestUpdater.cs
@@ -22,6 +22,12 @@ namespace GooglePlayInstant.Editor.AndroidManifest
     public interface IAndroidManifestUpdater
     {
         /// <summary>
+        /// Checks the AndroidManifest prior to building an instant app.
+        /// </summary>
+        /// <returns>An error message if there was a problem checking the manifest, or null if successful.</returns>
+        string CheckInstantManifest();
+
+        /// <summary>
         /// Update the AndroidManifest for building an instant app.
         /// </summary>
         /// <param name="uri">The Default URL to use, or null for a URL-less instant app.</param>

--- a/GooglePlayInstant/Editor/AndroidManifest/LegacyAndroidManifestUpdater.cs
+++ b/GooglePlayInstant/Editor/AndroidManifest/LegacyAndroidManifestUpdater.cs
@@ -28,6 +28,30 @@ namespace GooglePlayInstant.Editor.AndroidManifest
         private const string AndroidManifestAssetsDirectory = "Assets/Plugins/Android/";
         private const string AndroidManifestAssetsPath = AndroidManifestAssetsDirectory + "AndroidManifest.xml";
 
+        public string CheckInstantManifest()
+        {
+            if (!File.Exists(AndroidManifestAssetsPath))
+            {
+                return string.Format("Failed to locate file {0}", AndroidManifestAssetsPath);
+            }
+
+            string errorMessage;
+            var doc = XDocument.Load(AndroidManifestAssetsPath);
+            var hasCurrentPluginVersion = AndroidManifestHelper.HasCurrentPluginVersion(doc, out errorMessage);
+            if (errorMessage != null)
+            {
+                return errorMessage;
+            }
+
+            if (!hasCurrentPluginVersion)
+            {
+                doc.Save(AndroidManifestAssetsPath);
+                Debug.LogFormat("Successfully updated {0}", AndroidManifestAssetsPath);
+            }
+
+            return null;
+        }
+
         public string SwitchToInstant(Uri uri)
         {
             XDocument doc;

--- a/GooglePlayInstant/Editor/AndroidManifest/PostGenerateGradleProjectAndroidManifestUpdater.cs
+++ b/GooglePlayInstant/Editor/AndroidManifest/PostGenerateGradleProjectAndroidManifestUpdater.cs
@@ -63,6 +63,12 @@ namespace GooglePlayInstant.Editor.AndroidManifest
             doc.Save(manifestPath);
         }
 
+        public string CheckInstantManifest()
+        {
+            // Unused on 2018+
+            return null;
+        }
+
         public string SwitchToInstant(Uri uri)
         {
             // Unused on 2018+

--- a/GooglePlayInstant/Editor/PlayInstantBuilder.cs
+++ b/GooglePlayInstant/Editor/PlayInstantBuilder.cs
@@ -15,9 +15,11 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using GooglePlayInstant.Editor.AndroidManifest;
 using GooglePlayInstant.Editor.GooglePlayServices;
 using UnityEditor;
 using UnityEngine;
+
 #if UNITY_2018_1_OR_NEWER
 using UnityEditor.Build.Reporting;
 #endif
@@ -212,6 +214,13 @@ namespace GooglePlayInstant.Editor
         /// <returns>True if the build succeeded, false if it failed or was cancelled.</returns>
         public static bool Build(BuildPlayerOptions buildPlayerOptions)
         {
+            var checkInstantManifestResult = AndroidManifestHelper.GetAndroidManifestUpdater().CheckInstantManifest();
+            if (checkInstantManifestResult != null)
+            {
+                DisplayBuildError(string.Format("Failed to update manifest: {0}", checkInstantManifestResult));
+                return false;
+            }
+
             var buildReport = BuildPipeline.BuildPlayer(buildPlayerOptions);
 #if UNITY_2018_1_OR_NEWER
             switch (buildReport.summary.result)

--- a/GooglePlayInstant/Tests/Editor/AndroidManifest/AndroidManifestHelperTests.cs
+++ b/GooglePlayInstant/Tests/Editor/AndroidManifest/AndroidManifestHelperTests.cs
@@ -162,6 +162,66 @@ namespace GooglePlayInstant.Tests.Editor.AndroidManifest
         }
 
         [Test]
+        public void TestHasCurrentPluginVersion_NoManifestElement()
+        {
+            string errorMessage;
+            var doc = new XDocument();
+            Assert.IsFalse(AndroidManifestHelper.HasCurrentPluginVersion(doc, out errorMessage));
+            Assert.AreEqual(AndroidManifestHelper.PreconditionOneManifestElement, errorMessage);
+        }
+
+        [Test]
+        public void TestTestHasCurrentPluginVersion_NoApplicationElement()
+        {
+            string errorMessage;
+            var doc = new XDocument(new XElement(Manifest));
+            Assert.IsFalse(AndroidManifestHelper.HasCurrentPluginVersion(doc, out errorMessage));
+            Assert.AreEqual(AndroidManifestHelper.PreconditionOneApplicationElement, errorMessage);
+        }
+
+        [Test]
+        public void TestHasCurrentPluginVersion_NoPluginVersion()
+        {
+            string errorMessage;
+            var doc = new XDocument(new XElement(Manifest, AndroidNamespaceAttribute, new XElement(Application)));
+            Assert.IsFalse(AndroidManifestHelper.HasCurrentPluginVersion(doc, out errorMessage));
+            Assert.IsNull(errorMessage);
+        }
+
+        [Test]
+        public void TestHasCurrentPluginVersion_IncorrectPluginVersion()
+        {
+            string errorMessage;
+            var doc = new XDocument(new XElement(Manifest, AndroidNamespaceAttribute,
+                new XElement(Application,
+                    new XElement(MetaData,
+                        new XAttribute(AndroidNameXName, PlayInstantUnityPluginVersion),
+                        new XAttribute(AndroidValueXName, "Incorrect Version")))));
+            Assert.IsFalse(AndroidManifestHelper.HasCurrentPluginVersion(doc, out errorMessage));
+            Assert.IsNull(errorMessage);
+        }
+
+        [Test]
+        public void TestTestHasCurrentPluginVersion_TwoPluginVersions()
+        {
+            string errorMessage;
+            var doc = new XDocument(new XElement(Manifest, AndroidNamespaceAttribute,
+                new XElement(Application, PluginVersion, PluginVersion)));
+            Assert.IsFalse(AndroidManifestHelper.HasCurrentPluginVersion(doc, out errorMessage));
+            Assert.AreEqual(AndroidManifestHelper.PreconditionOnePluginVersion, errorMessage);
+        }
+
+        [Test]
+        public void TestTestHasCurrentPluginVersion_CorrectPluginVersion()
+        {
+            string errorMessage;
+            var doc = new XDocument(new XElement(Manifest, AndroidNamespaceAttribute,
+                new XElement(Application, PluginVersion)));
+            Assert.IsTrue(AndroidManifestHelper.HasCurrentPluginVersion(doc, out errorMessage));
+            Assert.IsNull(errorMessage);
+        }
+
+        [Test]
         public void TestConvertManifestToInstant_WithoutUrl()
         {
             var doc = new XDocument(InstalledManifestWithoutUrl);
@@ -237,6 +297,15 @@ namespace GooglePlayInstant.Tests.Editor.AndroidManifest
             var doc = new XDocument(new XElement(Manifest, AndroidNamespaceAttribute));
             var result = AndroidManifestHelper.ConvertManifestToInstant(doc, TestUri);
             Assert.AreEqual(AndroidManifestHelper.PreconditionOneApplicationElement, result);
+        }
+
+        [Test]
+        public void TestConvertManifestToInstant_TwoPluginVersions()
+        {
+            var doc = new XDocument(new XElement(Manifest, AndroidNamespaceAttribute,
+                new XElement(Application, PluginVersion, PluginVersion)));
+            var result = AndroidManifestHelper.ConvertManifestToInstant(doc, TestUri);
+            Assert.AreEqual(AndroidManifestHelper.PreconditionOnePluginVersion, result);
         }
 
         [Test]

--- a/GooglePlayInstant/Tests/Editor/AndroidManifest/AndroidManifestHelperTests.cs
+++ b/GooglePlayInstant/Tests/Editor/AndroidManifest/AndroidManifestHelperTests.cs
@@ -35,6 +35,7 @@ namespace GooglePlayInstant.Tests.Editor.AndroidManifest
         private const string IntentFilter = "intent-filter";
         private const string Manifest = "manifest";
         private const string MetaData = "meta-data";
+        private const string PlayInstantUnityPluginVersion = "play-instant-unity-plugin.version";
         private const string ValueTrue = "true";
         private const string AndroidNamespaceAlias = "android";
         private const string AndroidNamespaceUrl = "http://schemas.android.com/apk/res/android";
@@ -65,6 +66,11 @@ namespace GooglePlayInstant.Tests.Editor.AndroidManifest
         private static readonly XAttribute TargetSandboxVersion2Attribute =
             new XAttribute(XName.Get("targetSandboxVersion", AndroidNamespaceUrl), "2");
 
+        private static readonly XElement PluginVersion =
+            new XElement(MetaData,
+                new XAttribute(AndroidNameXName, PlayInstantUnityPluginVersion),
+                new XAttribute(AndroidValueXName, GooglePlayInstantUtils.PluginVersion));
+
         private static readonly XElement MainLauncherIntentFilter =
             new XElement(
                 IntentFilter,
@@ -94,7 +100,8 @@ namespace GooglePlayInstant.Tests.Editor.AndroidManifest
                     AndroidNamespaceAttribute,
                     DistributionNamespaceAttribute,
                     TargetSandboxVersion2Attribute,
-                    new XElement(Application, OtherBasicActivity, MainActivityNoUrls, OtherActivityWithViewIntent),
+                    new XElement(Application,
+                        OtherBasicActivity, MainActivityNoUrls, OtherActivityWithViewIntent, PluginVersion),
                     CreateDistributionModuleInstant(ValueTrue)));
 
         private static readonly XDocument InstalledManifestWithUrl =
@@ -122,7 +129,8 @@ namespace GooglePlayInstant.Tests.Editor.AndroidManifest
                             MainLauncherIntentFilter,
                             CreateViewIntentFilter("example.com", null),
                             CreateDefaultUrl("https://example.com/")),
-                        OtherActivityWithViewIntent),
+                        OtherActivityWithViewIntent,
+                        PluginVersion),
                     CreateDistributionModuleInstant(ValueTrue)));
 
         [Test]


### PR DESCRIPTION
Add a <meta-data> element to the <application> element of the Android
manifest indicating which version of the plugin was used.
This is only included for instant app builds.

Example:
<meta-data android:name="play-instant-unity-plugin.version" android:value="1.0"/>