### PR TITLE
Fixed save dialog issue on Windows

### DIFF
--- a/GooglePlayInstant/Editor/QuickDeploy/DialogHelper.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/DialogHelper.cs
@@ -102,14 +102,18 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         /// </summary>
         private static string AbsoluteToAssetsRelativePath(string absolutePath)
         {
-            var parentPath = Application.dataPath + Path.DirectorySeparatorChar;
-            var index = absolutePath.IndexOf(parentPath, StringComparison.Ordinal);
-            if (index != 0)
+            var parentPath = Application.dataPath;
+            if (!absolutePath.StartsWith(parentPath, StringComparison.Ordinal))
             {
                 return null;
             }
 
-            var relativePath = absolutePath.Remove(index, parentPath.Length);
+            if (absolutePath.Length == parentPath.Length)
+            {
+                return "Assets";
+            }
+
+            var relativePath = absolutePath.Remove(0, parentPath.Length + 1);
             return Path.Combine("Assets", relativePath);
         }
     }

--- a/GooglePlayInstant/Editor/QuickDeploy/DialogHelper.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/DialogHelper.cs
@@ -129,8 +129,8 @@ namespace GooglePlayInstant.Editor.QuickDeploy
                 return null;
             }
 
-            char[] pathSeparator = {'/'};
-            string lastSharedDirectoryName = parentPath.Split(pathSeparator).Last();
+            // In general this directory will be "Assets".
+            var lastSharedDirectoryName = parentPath.Split('/').Last();
 
             if (absolutePath.Length == parentPath.Length)
             {

--- a/GooglePlayInstant/Editor/QuickDeploy/DialogHelper.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/DialogHelper.cs
@@ -13,9 +13,13 @@
 // limitations under the License.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.IO;
+using System.Linq;
 using UnityEditor;
 using UnityEngine;
+
+[assembly: InternalsVisibleTo("GooglePlayInstant.Tests.Editor.QuickDeploy")]
 
 namespace GooglePlayInstant.Editor.QuickDeploy
 {
@@ -100,21 +104,41 @@ namespace GooglePlayInstant.Editor.QuickDeploy
         /// Converts the specified absolute path to a path relative to the Assets folder.
         /// Returns null if the path does not contains the Assets folder.
         /// </summary>
-        private static string AbsoluteToAssetsRelativePath(string absolutePath)
+        internal static string AbsoluteToAssetsRelativePath(string absolutePath)
         {
-            var parentPath = Application.dataPath;
+            return AbsoluteToRelativePath(absolutePath, Application.dataPath);
+        }
+
+        // Assumes the paths are separated with forward slashes.
+        // Visible for testing.
+        internal static string AbsoluteToRelativePath(string absolutePath, string parentPath)
+        {
+            if (string.IsNullOrEmpty(absolutePath) || string.IsNullOrEmpty(parentPath))
+            {
+                return null;
+            }
+
+            // Strip trailing slash.
+            if (parentPath.Last() == '/')
+            {
+                parentPath = parentPath.Remove(parentPath.Length - 1);
+            }
+
             if (!absolutePath.StartsWith(parentPath, StringComparison.Ordinal))
             {
                 return null;
             }
 
+            char[] pathSeparator = {'/'};
+            string lastSharedDirectoryName = parentPath.Split(pathSeparator).Last();
+
             if (absolutePath.Length == parentPath.Length)
             {
-                return "Assets";
+                return lastSharedDirectoryName;
             }
 
             var relativePath = absolutePath.Remove(0, parentPath.Length + 1);
-            return Path.Combine("Assets", relativePath);
+            return Path.Combine(lastSharedDirectoryName, relativePath);
         }
     }
 }

--- a/GooglePlayInstant/Tests/Editor/QuickDeploy/DialogHelperTest.cs
+++ b/GooglePlayInstant/Tests/Editor/QuickDeploy/DialogHelperTest.cs
@@ -19,9 +19,6 @@ using UnityEngine;
 
 namespace GooglePlayInstant.Tests.Editor.QuickDeploy
 {
-    /// <summary>
-    /// Contains unit tests for LoadingScreenGenerator methods.
-    /// </summary>
     [TestFixture]
     public class DialogHelperTest
     {

--- a/GooglePlayInstant/Tests/Editor/QuickDeploy/DialogHelperTest.cs
+++ b/GooglePlayInstant/Tests/Editor/QuickDeploy/DialogHelperTest.cs
@@ -1,0 +1,75 @@
+﻿// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.IO;
+using GooglePlayInstant.Editor.QuickDeploy;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace GooglePlayInstant.Tests.Editor.QuickDeploy
+{
+    /// <summary>
+    /// Contains unit tests for LoadingScreenGenerator methods.
+    /// </summary>
+    [TestFixture]
+    public class DialogHelperTest
+    {
+        [Test]
+        public void TestAbsoluteToAssetsRelativePath()
+        {
+            var sceneRelativePath = "Scenes/LoadingScene.unity";
+            var scenePath = Path.Combine(Application.dataPath, sceneRelativePath);
+            Assert.AreEqual("Assets/Scenes/LoadingScene.unity", DialogHelper.AbsoluteToAssetsRelativePath(scenePath));
+        }
+
+        [Test]
+        public void TestAbsoluteToRelativePath_ValidPaths()
+        {
+            var assetsPath = "C:/Documents/Project/Assets";
+            var scenePath = "C:/Documents/Project/Assets/Scenes/LoadingScene.unity";
+            Assert.AreEqual("Assets/Scenes/LoadingScene.unity",
+                DialogHelper.AbsoluteToRelativePath(scenePath, assetsPath));
+        }
+
+        [Test]
+        public void TestAbsoluteToRelativePath_EqualPaths()
+        {
+            var assetsPath = "C:/Documents/Project/Assets/";
+            Assert.AreEqual("Assets", DialogHelper.AbsoluteToRelativePath(assetsPath, assetsPath));
+        }
+
+        [Test]
+        public void TestAbsoluteToRelativePath_RedundantPaths()
+        {
+            var assetsPath = "C:/Documents/Project/Assets";
+            var scenePath = "C:/Documents/Project/Assets/C:/Documents/Project/Assets/LoadingScene.unity";
+            Assert.AreEqual("Assets/C:/Documents/Project/Assets/LoadingScene.unity",
+                DialogHelper.AbsoluteToRelativePath(scenePath, assetsPath));
+        }
+
+        [Test]
+        public void TestAbsoluteToRelativePath_SeparatePaths()
+        {
+            var assetsPath = "C:/Documents/Project/Assets/";
+            var scenePath = "C:/SomeOtherFolder/Scenes/LoadingScene.unity";
+            Assert.IsNull(DialogHelper.AbsoluteToRelativePath(scenePath, assetsPath));
+        }
+
+        [Test]
+        public void TestAbsoluteToRelativePath_EmptyPaths()
+        {
+            Assert.IsNull(DialogHelper.AbsoluteToRelativePath("", ""));
+        }
+    }
+}

--- a/GooglePlayInstant/Tests/Editor/QuickDeploy/LoadingScreenGeneratorTest.cs
+++ b/GooglePlayInstant/Tests/Editor/QuickDeploy/LoadingScreenGeneratorTest.cs
@@ -21,9 +21,6 @@ using Object = UnityEngine.Object;
 
 namespace GooglePlayInstant.Tests.Editor.QuickDeploy
 {
-    /// <summary>
-    /// Contains unit tests for LoadingScreenGenerator methods.
-    /// </summary>
     [TestFixture]
     public class LoadingScreenGeneratorTest
     {


### PR DESCRIPTION
The issue blocked users from selecting a path for the generated loading scene. Instead, it would mistakenly declare that the chosen path was outside the Assets folder, and throw an error.