### PR TITLE
Fixed issue with building for play console on windows

### DIFF
--- a/GooglePlayInstant/Editor/GooglePlayServices/CommandLine.cs
+++ b/GooglePlayInstant/Editor/GooglePlayServices/CommandLine.cs
@@ -677,14 +677,6 @@ namespace GooglePlayInstant.Editor.GooglePlayServices
         {
             return string.Format("\"{0}\"", path);
         }
-        
-        /// <summary>
-        /// Returns the specified argument in double quotes if it contains a space.
-        /// </summary>
-        public static string QuoteIfNecessary(string path)
-        {
-            return path.Contains(" ") ? QuotePath(path) : path;
-        }
 
 #if UNITY_EDITOR
         /// <summary>

--- a/GooglePlayInstant/Editor/GooglePlayServices/CommandLine.cs
+++ b/GooglePlayInstant/Editor/GooglePlayServices/CommandLine.cs
@@ -677,6 +677,14 @@ namespace GooglePlayInstant.Editor.GooglePlayServices
         {
             return string.Format("\"{0}\"", path);
         }
+        
+        /// <summary>
+        /// Returns the specified argument in double quotes if it contains a space.
+        /// </summary>
+        public static string QuoteIfNecessary(string path)
+        {
+            return path.Contains(" ") ? QuotePath(path) : path;
+        }
 
 #if UNITY_EDITOR
         /// <summary>

--- a/GooglePlayInstant/Editor/ZipUtils.cs
+++ b/GooglePlayInstant/Editor/ZipUtils.cs
@@ -34,11 +34,22 @@ namespace GooglePlayInstant.Editor
                 throw new ArgumentException("Spaces are not supported for inputFileName.", "inputFileName");
             }
 
+            // On windows, we can't support a directory with spaces, because jar does not support quotes around the
+            // inputDirectoryName.
+#if UNITY_EDITOR_WIN
+            if (inputDirectoryName.Contains(" "))
+            {
+                throw new ArgumentException("Spaces are not supported for inputDirectoryName.", "inputDirectoryName");
+            }
+#else
+            inputDirectoryName = CommandLine.QuotePath(inputDirectoryName);
+#endif
+
             // Create zip file with options "0" (no per-file compression) and "M" (no JAR manifest file).
             var arguments = string.Format(
                 "c0Mf {0} -C {1} {2}",
                 CommandLine.QuotePath(zipFilePath),
-                CommandLine.QuotePath(inputDirectoryName),
+                inputDirectoryName,
                 inputFileName);
             var result = CommandLine.Run(JavaUtilities.JarBinaryPath, arguments);
             return result.exitCode == 0 ? null : result.message;


### PR DESCRIPTION
Jar was failing to zip files because of quotes around the -C argument. To fix it, we unquote that particular argument and throw an error if the path contains spaces.