### PR TITLE
Fixed Unity package export issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,11 +84,11 @@ def buildApp(def projectPath, def buildMethod, def logFile, def outputFile) {
 task exportPlugin {
     description 'Creates and exports the Plugin as a .unitypackage'
     def buildPath = "${playInstantBuildPath}/plugin"
-    doFirst{
+    doFirst {
         copyFiles(buildPath, ['Tests'])
     }
 
-    doLast{
+    doLast {
         def utilsFilePath = "${buildPath}/Assets/GooglePlayInstant/GooglePlayInstantUtils.cs"
         def utilsFileContents = new File(utilsFilePath).text
         def pluginVersion = (utilsFileContents =~ /PluginVersion = "(.+)";/)[0][1]

--- a/build.gradle
+++ b/build.gradle
@@ -81,56 +81,33 @@ def buildApp(def projectPath, def buildMethod, def logFile, def outputFile) {
     }
 }
 
-def exportUnityPackage(def projectPath, def packageFilePrefix) {
-    description 'Creates a .unitypackage file with the specified prefix'
-
-    // Extract the plugin version from a constant defined in code.
-    def utilsFilePath = "${projectPath}/Assets/GooglePlayInstant/GooglePlayInstantUtils.cs"
+task exportPlugin {
+    description 'Creates and exports the Plugin as a .unitypackage'
+    def buildPath = "${playInstantBuildPath}/plugin"
+    def utilsFilePath = "${buildPath}/Assets/GooglePlayInstant/GooglePlayInstantUtils.cs"
     def utilsFileContents = new File(utilsFilePath).text
     def pluginVersion = (utilsFileContents =~ /PluginVersion = "(.+)";/)[0][1]
-
-    def packageFileName = "${packageFilePrefix}-${pluginVersion}.unitypackage"
+    def packageFileName = "google-play-instant-plugin-${pluginVersion}.unitypackage"
     def exportFileName = file(packageFileName).getPath()
     def logFile = file("${packageFileName}.log").getPath()
     def argv = [
             '-batchmode',
             '-nographics',
             '-projectPath',
-            projectPath,
+            buildPath,
             '-logFile',
             logFile,
             '-exportPackage',
-            'Assets',
+            'Assets/GooglePlayInstant',
             exportFileName,
             '-quit'
     ]
-    exec {
-        executable unityExe
-        args argv
-    }
-}
-
-task exportPlugin {
-    description 'Creates and exports the Plugin as a .unitypackage'
-    def buildPath = "${playInstantBuildPath}/plugin"
     doLast {
         copyFiles(buildPath, ['Tests'])
-        exportUnityPackage(buildPath, 'google-play-instant-plugin')
-    }
-}
-
-task exportSampleSphereBlast {
-    description 'Creates and exports the Plugin unity package'
-    def buildPath = "${playInstantBuildPath}/sphereblast"
-    doFirst {
-        copyFiles(buildPath, ['Tests'])
-        copy {
-            from 'GooglePlayInstant/Samples/SphereBlast'
-            into "${buildPath}/Assets/SphereBlast"
+        exec {
+            executable unityExe
+            args argv
         }
-    }
-    doLast {
-        exportUnityPackage(buildPath, 'google-play-instant-sphereblast')
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -84,26 +84,29 @@ def buildApp(def projectPath, def buildMethod, def logFile, def outputFile) {
 task exportPlugin {
     description 'Creates and exports the Plugin as a .unitypackage'
     def buildPath = "${playInstantBuildPath}/plugin"
-    def utilsFilePath = "${buildPath}/Assets/GooglePlayInstant/GooglePlayInstantUtils.cs"
-    def utilsFileContents = new File(utilsFilePath).text
-    def pluginVersion = (utilsFileContents =~ /PluginVersion = "(.+)";/)[0][1]
-    def packageFileName = "google-play-instant-plugin-${pluginVersion}.unitypackage"
-    def exportFileName = file(packageFileName).getPath()
-    def logFile = file("${packageFileName}.log").getPath()
-    def argv = [
-            '-batchmode',
-            '-nographics',
-            '-projectPath',
-            buildPath,
-            '-logFile',
-            logFile,
-            '-exportPackage',
-            'Assets/GooglePlayInstant',
-            exportFileName,
-            '-quit'
-    ]
-    doLast {
+    doFirst{
         copyFiles(buildPath, ['Tests'])
+    }
+
+    doLast{
+        def utilsFilePath = "${buildPath}/Assets/GooglePlayInstant/GooglePlayInstantUtils.cs"
+        def utilsFileContents = new File(utilsFilePath).text
+        def pluginVersion = (utilsFileContents =~ /PluginVersion = "(.+)";/)[0][1]
+        def packageFileName = "google-play-instant-plugin-${pluginVersion}.unitypackage"
+        def exportFileName = file(packageFileName).getPath()
+        def logFile = file("${packageFileName}.log").getPath()
+        def argv = [
+                '-batchmode',
+                '-nographics',
+                '-projectPath',
+                buildPath,
+                '-logFile',
+                logFile,
+                '-exportPackage',
+                'Assets/GooglePlayInstant',
+                exportFileName,
+                '-quit'
+        ]
         exec {
             executable unityExe
             args argv


### PR DESCRIPTION
The exportPlugin task was generating a Unity package with Assets/ as its root folder instead of GooglePlayInstant/