### PR TITLE
Fix warnings and window sizes

### DIFF
--- a/GooglePlayInstant/Editor/BuildSettingsWindow.cs
+++ b/GooglePlayInstant/Editor/BuildSettingsWindow.cs
@@ -27,6 +27,8 @@ namespace GooglePlayInstant.Editor
     {
         public const string WindowTitle = "Play Instant Build Settings";
         private const string InstantAppsHostName = "instant.apps";
+        private const int WindowMinWidth = 475;
+        private const int WindowMinHeight = 400;
         private const int FieldWidth = 175;
         private static readonly string[] PlatformOptions = {"Installed", "Instant"};
 
@@ -48,7 +50,8 @@ namespace GooglePlayInstant.Editor
         /// </summary>
         public static void ShowWindow()
         {
-            _windowInstance = GetWindow(typeof(BuildSettingsWindow), true, WindowTitle) as BuildSettingsWindow;
+            _windowInstance = (BuildSettingsWindow) GetWindow(typeof(BuildSettingsWindow), true, WindowTitle);
+            _windowInstance.minSize = new Vector2(WindowMinWidth, WindowMinHeight);
         }
 
         private void OnDestroy()

--- a/GooglePlayInstant/Editor/PlayerSettingsWindow.cs
+++ b/GooglePlayInstant/Editor/PlayerSettingsWindow.cs
@@ -31,7 +31,7 @@ namespace GooglePlayInstant.Editor
         /// </summary>
         public static void ShowWindow()
         {
-            var window =GetWindow(typeof(PlayerSettingsWindow), true, "Play Instant Player Settings");
+            var window = GetWindow(typeof(PlayerSettingsWindow), true, "Play Instant Player Settings");
             window.minSize = new Vector2(WindowMinWidth, WindowMinHeight);
         }
 

--- a/GooglePlayInstant/Editor/PlayerSettingsWindow.cs
+++ b/GooglePlayInstant/Editor/PlayerSettingsWindow.cs
@@ -23,12 +23,16 @@ namespace GooglePlayInstant.Editor
     /// </summary>
     public class PlayerSettingsWindow : EditorWindow
     {
+        private const int WindowMinWidth = 475;
+        private const int WindowMinHeight = 400;
+
         /// <summary>
         /// Displays this window, creating it if necessary.
         /// </summary>
         public static void ShowWindow()
         {
-            GetWindow(typeof(PlayerSettingsWindow), true, "Play Instant Player Settings");
+            var window =GetWindow(typeof(PlayerSettingsWindow), true, "Play Instant Player Settings");
+            window.minSize = new Vector2(WindowMinWidth, WindowMinHeight);
         }
 
         private void OnGUI()

--- a/GooglePlayInstant/Editor/PluginUpdateWindow.cs
+++ b/GooglePlayInstant/Editor/PluginUpdateWindow.cs
@@ -333,6 +333,22 @@ namespace GooglePlayInstant.Editor
             window.minSize = new Vector2(WindowMinWidth, WindowMinHeight);
         }
 
+        // Returns a new LatestReleaseResponse. This is primarily here to set fields and avoid Unity warning CS0649.
+        private static LatestReleaseResponse CreateLatestReleaseResponse(string version, string downloadUrl)
+        {
+            return new LatestReleaseResponse
+            {
+                tag_name = version,
+                assets = new[]
+                {
+                    new LatestReleaseAssets
+                    {
+                        browser_download_url = downloadUrl
+                    }
+                }
+            };
+        }
+
         // Classes used for deserializing a JSON response based on https://developer.github.com/v3/repos/releases/
         [Serializable]
         private class LatestReleaseResponse

--- a/GooglePlayInstant/Editor/PluginUpdateWindow.cs
+++ b/GooglePlayInstant/Editor/PluginUpdateWindow.cs
@@ -333,23 +333,9 @@ namespace GooglePlayInstant.Editor
             window.minSize = new Vector2(WindowMinWidth, WindowMinHeight);
         }
 
-        // Returns a new LatestReleaseResponse. This is primarily here to set fields and avoid Unity warning CS0649.
-        private static LatestReleaseResponse CreateLatestReleaseResponse(string version, string downloadUrl)
-        {
-            return new LatestReleaseResponse
-            {
-                tag_name = version,
-                assets = new[]
-                {
-                    new LatestReleaseAssets
-                    {
-                        browser_download_url = downloadUrl
-                    }
-                }
-            };
-        }
-
         // Classes used for deserializing a JSON response based on https://developer.github.com/v3/repos/releases/
+        // Since these fields are only set by JsonUtility.FromJson(), we need to explicitly disable warning CS0649.
+#pragma warning disable CS0649
         [Serializable]
         private class LatestReleaseResponse
         {
@@ -363,5 +349,6 @@ namespace GooglePlayInstant.Editor
         {
             public string browser_download_url;
         }
+#pragma warning restore CS0649
     }
 }


### PR DESCRIPTION
Clean up 3 Unity warnings on unused fields.
Also set minimum window size on 2 windows.