### PR TITLE
Switch version for native AAB builds from 2018.3 to 2018.4

### DIFF
--- a/GooglePlayInstant/Editor/AppBundlePublisher.cs
+++ b/GooglePlayInstant/Editor/AppBundlePublisher.cs
@@ -28,7 +28,7 @@ namespace GooglePlayInstant.Editor
         /// </summary>
         public static void Build()
         {
-#if !UNITY_2018_3_OR_NEWER
+#if !UNITY_2018_4_OR_NEWER
             if (!AndroidAssetPackagingTool.CheckConvert())
             {
                 return;
@@ -66,10 +66,13 @@ namespace GooglePlayInstant.Editor
         {
             bool buildResult;
             Debug.LogFormat("Building app bundle: {0}", aabFilePath);
-#if UNITY_2018_3_OR_NEWER
+#if UNITY_2018_4_OR_NEWER
             EditorUserBuildSettings.buildAppBundle = true;
             var buildPlayerOptions = PlayInstantBuilder.CreateBuildPlayerOptions(aabFilePath, BuildOptions.None);
-            buildResult = PlayInstantBuilder.Build(buildPlayerOptions))
+            buildResult = PlayInstantBuilder.Build(buildPlayerOptions);
+#elif UNITY_2018_3_OR_NEWER
+            EditorUserBuildSettings.buildAppBundle = false;
+            buildResult = AppBundleBuilder.Build(aabFilePath);
 #else
             buildResult = AppBundleBuilder.Build(aabFilePath);
 #endif
@@ -78,6 +81,7 @@ namespace GooglePlayInstant.Editor
                 // Do not log in case of failure. The method we called was responsible for logging.
                 Debug.LogFormat("Finished building app bundle: {0}", aabFilePath);
             }
+
             return buildResult;
         }
     }

--- a/GooglePlayInstant/Editor/PlayInstantEditorMenu.cs
+++ b/GooglePlayInstant/Editor/PlayInstantEditorMenu.cs
@@ -87,7 +87,7 @@ namespace GooglePlayInstant.Editor
             QuickDeployWindow.ShowWindow();
         }
 
-#if UNITY_2018_3_OR_NEWER
+#if UNITY_2018_4_OR_NEWER
         [MenuItem(PlayInstant + "Build Android App Bundle...", false, 300)]
         private static void BuildAndroidAppBundle()
         {


### PR DESCRIPTION
The version of bundletool that will come with 2018.3 isn't recent
enough for instant apps with uncompressed native libraries. We
bump up the minimum version to 2018.4 and hope that one will be
new enough.

Also fixed a compilation error that was guarded by an #if.