### PR TITLE
Fix Unity 2018 Gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@
  */
 buildscript {
     repositories {
+        google()
         jcenter()
         mavenLocal()
     }


### PR DESCRIPTION
IntelliJ-core jar is missing and google depot needs to be added.