### PR TITLE
Fixed failing test on windows

### DIFF
--- a/GooglePlayInstant/Editor/QuickDeploy/DialogHelper.cs
+++ b/GooglePlayInstant/Editor/QuickDeploy/DialogHelper.cs
@@ -138,7 +138,9 @@ namespace GooglePlayInstant.Editor.QuickDeploy
             }
 
             var relativePath = absolutePath.Remove(0, parentPath.Length + 1);
-            return Path.Combine(lastSharedDirectoryName, relativePath);
+
+            // Combine paths manually because Path.Combine will use backslashes on windows.
+            return string.Format("{0}/{1}", lastSharedDirectoryName, relativePath);
         }
     }
 }

--- a/GooglePlayInstant/Tests/Editor/QuickDeploy/DialogHelperTest.cs
+++ b/GooglePlayInstant/Tests/Editor/QuickDeploy/DialogHelperTest.cs
@@ -43,7 +43,7 @@ namespace GooglePlayInstant.Tests.Editor.QuickDeploy
         public void TestAbsoluteToRelativePath_EqualPaths()
         {
             var assetsPath = "C:/Documents/Project/Assets/";
-            Assert.AreEqual("Assets", DialogHelper.AbsoluteToRelativePath(assetsPath, assetsPath));
+            Assert.AreEqual("Assets/", DialogHelper.AbsoluteToRelativePath(assetsPath, assetsPath));
         }
 
         [Test]


### PR DESCRIPTION
The AbsoluteToRelativePath function was returning paths with a mix of back and forward slashes, instead of paths with just forward slashes.