### PR TITLE
Fix ApkSigner usage with .NET 4.5

### DIFF
--- a/GooglePlayInstant/Editor/AppBundlePublisher.cs
+++ b/GooglePlayInstant/Editor/AppBundlePublisher.cs
@@ -76,7 +76,7 @@ namespace GooglePlayInstant.Editor
 #else
             buildResult = AppBundleBuilder.Build(aabFilePath);
 #endif
-            if (!buildResult)
+            if (buildResult)
             {
                 // Do not log in case of failure. The method we called was responsible for logging.
                 Debug.LogFormat("Finished building app bundle: {0}", aabFilePath);


### PR DESCRIPTION
Signing App Bundles with .NET 4.5 was failing due to inclusion of
a byte order marker (BOM) prefix to the keystore password. Change the
output encoding to explicitly not include a BOM.

Remove line indicating when processes are started; it was there
originally for debugging an issue that no longer occurs.

Fix logging of a message when App Bundle building is complete.