### PR TITLE
Fixed issue where Build and Run would hang on Unity versions 2018.3+

### DIFF
--- a/GooglePlayInstant/Editor/PlayInstantRunner.cs
+++ b/GooglePlayInstant/Editor/PlayInstantRunner.cs
@@ -73,7 +73,7 @@ namespace GooglePlayInstant.Editor
             var window = PostBuildCommandLineDialog.CreateDialog("Install and run app");
             window.modal = false;
             window.summaryText = "Installing app on device";
-            window.bodyText = "The APK built successfully. Waiting for scripts to reload...\n";
+            window.bodyText = "The APK built successfully.\n\n";
             window.autoScrollToBottom = true;
             window.CommandLineParams = new CommandLineParameters
             {

--- a/GooglePlayInstant/Editor/PostBuildCommandLineDialog.cs
+++ b/GooglePlayInstant/Editor/PostBuildCommandLineDialog.cs
@@ -18,11 +18,12 @@ using UnityEngine;
 namespace GooglePlayInstant.Editor
 {
     /// <summary>
-    /// A CommandLineDialog that waits to run the specified command until after an AppDomain reset.
+    /// A CommandLineDialog that potentially waits to run the specified command until after an AppDomain reset.
     ///
-    /// On Unity versions older than 2018.3, Several seconds after a call to BuildPlayer finishes, Unity reloads all
-    /// Editor scripts and resets the AppDomain, causing any running threads to be aborted. This EditorWindow waits to
-    /// run the specified command until after the AppDomain is reset.
+    /// Unity versions prior to 2018.3 reload all Editor scripts a few seconds after a call to BuildPlayer finishes.
+    /// This reload also resets the AppDomain and aborts any actively running threads, including any threads managing a
+    /// child process. This EditorWindow therefore waits to run the specified command until after the AppDomain is
+    /// reset.
     /// </summary>
     public class PostBuildCommandLineDialog : CommandLineDialog
     {
@@ -43,8 +44,9 @@ namespace GooglePlayInstant.Editor
         protected override void Update()
         {
 #if UNITY_2018_3_OR_NEWER
-            // On newer versions of Unity, the AppDomain does not reset after building.
-            // In this case, we run the command when the window is first shown.
+            // Starting with Unity 2018.3 the AppDomain is not reset after building an APK.
+            // In this case we run the command when the window is first shown.
+            // Note: some beta versions of 2018.3 reset the AppDomain as in earlier versions of Unity.
             if (!_nonserializedField)
             {
                 _nonserializedField = true;

--- a/GooglePlayInstant/Editor/PostBuildCommandLineDialog.cs
+++ b/GooglePlayInstant/Editor/PostBuildCommandLineDialog.cs
@@ -64,12 +64,13 @@ namespace GooglePlayInstant.Editor
                 _nonserializedField = true;
                 if (_serializedField)
                 {
-                    Debug.Log("Scripts have been reloaded.");
+                    Debug.Log("The AppDomain has been reset.");
                     RunCommandAsync();
                 }
                 else
                 {
-                    Debug.Log("Waiting for scripts to reload...");
+                    bodyText += "Waiting for scripts to reload...\n\n";
+                    Debug.Log("Waiting for the AppDomain reset...");
                     _serializedField = true;
                 }
             }


### PR DESCRIPTION
In Unity versions 2018.3 and newer, the AppDomain isn't reset after building, which causes PostBuildCommandLineDialog to wait indefinitely.

Now, PostBuildCommandLineDialog will only wait for the AppDomain reset in versions older than 2018.3.