### PR TITLE
Download bundletool for command line builds

### DIFF
--- a/GooglePlayInstant/Editor/Bundletool.cs
+++ b/GooglePlayInstant/Editor/Bundletool.cs
@@ -72,21 +72,28 @@ namespace GooglePlayInstant.Editor
 #endif
 
         /// <summary>
-        /// Returns the path to the bundletool jar within the project's Library directory.
+        /// The path to the bundletool jar within the project's Library directory.
         /// </summary>
-        public static string GetBundletoolJarPath()
+        public static string BundletoolJarPath
         {
-            var library = Directory.CreateDirectory("Library");
-            return Path.Combine(library.FullName, string.Format("bundletool-all-{0}.jar", BundletoolVersion));
+            get
+            {
+                var library = Directory.CreateDirectory("Library");
+                return Path.Combine(library.FullName, string.Format("bundletool-all-{0}.jar", BundletoolVersion));
+            }
         }
 
         /// <summary>
-        /// Returns the URL used to download the bundletool jar.
+        /// The URL used to download the bundletool jar.
         /// </summary>
-        public static string GetBundletoolDownloadUrl()
+        public static string BundletoolDownloadUrl
         {
-            return string.Format(
-                "https://github.com/google/bundletool/releases/download/{0}/bundletool-all-{0}.jar", BundletoolVersion);
+            get
+            {
+                return string.Format(
+                    "https://github.com/google/bundletool/releases/download/{0}/bundletool-all-{0}.jar",
+                    BundletoolVersion);
+            }
         }
 
         /// <summary>
@@ -95,7 +102,7 @@ namespace GooglePlayInstant.Editor
         /// </summary>
         public static bool CheckBundletool()
         {
-            var bundletoolJarPath = GetBundletoolJarPath();
+            var bundletoolJarPath = BundletoolJarPath;
             if (File.Exists(bundletoolJarPath))
             {
                 return true;
@@ -117,7 +124,7 @@ namespace GooglePlayInstant.Editor
 
             var arguments = string.Format(
                 "-jar {0} build-bundle --config={1} --modules={2} --output={3}",
-                CommandLine.QuotePath(GetBundletoolJarPath()),
+                CommandLine.QuotePath(BundletoolJarPath),
                 CommandLine.QuotePath(bundleConfigJsonFile),
                 CommandLine.QuotePath(baseModuleZip),
                 CommandLine.QuotePath(outputFile));

--- a/GooglePlayInstant/Editor/Bundletool.cs
+++ b/GooglePlayInstant/Editor/Bundletool.cs
@@ -23,7 +23,7 @@ namespace GooglePlayInstant.Editor
     /// </summary>
     public static class Bundletool
     {
-        public const string BundletoolVersion = "0.6.0";
+        public const string BundletoolVersion = "0.7.2";
 
         /// <summary>
         /// BundleTool config optimized for Unity-based instant apps.
@@ -78,6 +78,15 @@ namespace GooglePlayInstant.Editor
         {
             var library = Directory.CreateDirectory("Library");
             return Path.Combine(library.FullName, string.Format("bundletool-all-{0}.jar", BundletoolVersion));
+        }
+
+        /// <summary>
+        /// Returns the URL used to download the bundletool jar.
+        /// </summary>
+        public static string GetBundletoolDownloadUrl()
+        {
+            return string.Format(
+                "https://github.com/google/bundletool/releases/download/{0}/bundletool-all-{0}.jar", BundletoolVersion);
         }
 
         /// <summary>

--- a/GooglePlayInstant/Editor/BundletoolDownloadWindow.cs
+++ b/GooglePlayInstant/Editor/BundletoolDownloadWindow.cs
@@ -123,11 +123,9 @@ namespace GooglePlayInstant.Editor
         private void StartDownload()
         {
             Debug.Log("Downloading bundletool...");
-            var bundletoolUri = string.Format(
-                "https://github.com/google/bundletool/releases/download/{0}/bundletool-all-{0}.jar",
-                Bundletool.BundletoolVersion);
             _downloadRequest =
-                GooglePlayInstantUtils.StartFileDownload(bundletoolUri, Bundletool.GetBundletoolJarPath());
+                GooglePlayInstantUtils.StartFileDownload(
+                    Bundletool.GetBundletoolDownloadUrl(), Bundletool.GetBundletoolJarPath());
         }
 
         /// <summary>

--- a/GooglePlayInstant/Editor/BundletoolDownloadWindow.cs
+++ b/GooglePlayInstant/Editor/BundletoolDownloadWindow.cs
@@ -83,7 +83,7 @@ namespace GooglePlayInstant.Editor
                 }
 
                 // Download succeeded.
-                var bundletoolJarPath = Bundletool.GetBundletoolJarPath();
+                var bundletoolJarPath = Bundletool.BundletoolJarPath;
                 GooglePlayInstantUtils.FinishFileDownload(_downloadRequest, bundletoolJarPath);
                 _downloadRequest.Dispose();
                 _downloadRequest = null;
@@ -125,7 +125,7 @@ namespace GooglePlayInstant.Editor
             Debug.Log("Downloading bundletool...");
             _downloadRequest =
                 GooglePlayInstantUtils.StartFileDownload(
-                    Bundletool.GetBundletoolDownloadUrl(), Bundletool.GetBundletoolJarPath());
+                    Bundletool.BundletoolDownloadUrl, Bundletool.BundletoolJarPath);
         }
 
         /// <summary>

--- a/GooglePlayInstant/Samples/TestApp/Editor/TestAppBuilder.cs
+++ b/GooglePlayInstant/Samples/TestApp/Editor/TestAppBuilder.cs
@@ -55,7 +55,7 @@ namespace GooglePlayInstant.Samples.TestApp.Editor
 
         private static void DownloadBundletoolIfNecessary()
         {
-            var bundletoolJarPath = Bundletool.GetBundletoolJarPath();
+            var bundletoolJarPath = Bundletool.BundletoolJarPath;
             if (File.Exists(bundletoolJarPath))
             {
                 Debug.LogFormat("Found existing bundletool: {0}", bundletoolJarPath);
@@ -64,7 +64,7 @@ namespace GooglePlayInstant.Samples.TestApp.Editor
 
             var arguments =
                 string.Format(
-                    "{0} -O {1}", Bundletool.GetBundletoolDownloadUrl(), CommandLine.QuotePath(bundletoolJarPath));
+                    "{0} -O {1}", Bundletool.BundletoolDownloadUrl, CommandLine.QuotePath(bundletoolJarPath));
             var result = CommandLine.Run("wget", arguments);
             if (result.exitCode == 0)
             {

--- a/GooglePlayInstant/Samples/TestApp/Editor/TestAppBuilder.cs
+++ b/GooglePlayInstant/Samples/TestApp/Editor/TestAppBuilder.cs
@@ -13,8 +13,11 @@
 // limitations under the License.
 
 using System;
+using System.IO;
 using GooglePlayInstant.Editor;
+using GooglePlayInstant.Editor.GooglePlayServices;
 using UnityEditor;
+using UnityEngine;
 
 namespace GooglePlayInstant.Samples.TestApp.Editor
 {
@@ -42,10 +45,34 @@ namespace GooglePlayInstant.Samples.TestApp.Editor
             }
 
             // Also Build an AAB to test Android App Bundle build.
+            DownloadBundletoolIfNecessary();
             var aabPath = apkPath.Substring(0, apkPath.Length - 3) + "aab";
             if (!AppBundlePublisher.Build(aabPath))
             {
                 throw new Exception("AAB build failed");
+            }
+        }
+
+        private static void DownloadBundletoolIfNecessary()
+        {
+            var bundletoolJarPath = Bundletool.GetBundletoolJarPath();
+            if (File.Exists(bundletoolJarPath))
+            {
+                Debug.LogFormat("Found existing bundletool: {0}", bundletoolJarPath);
+                return;
+            }
+
+            var arguments =
+                string.Format(
+                    "{0} -O {1}", Bundletool.GetBundletoolDownloadUrl(), CommandLine.QuotePath(bundletoolJarPath));
+            var result = CommandLine.Run("wget", arguments);
+            if (result.exitCode == 0)
+            {
+                Debug.LogFormat("Downloaded bundletool: {0}", bundletoolJarPath);
+            }
+            else
+            {
+                throw new Exception("Failed to download bundletool: " + result.message);
             }
         }
     }


### PR DESCRIPTION
Use wget to download the bundletool jar if necessary.

Also update bundletool from 0.6.0 to 0.7.2.