### PR TITLE
Introduce workaround for Unity 2019.2 automated builds

### DIFF
--- a/GooglePlayInstant/Editor/BuildTools/AndroidSdk.cs
+++ b/GooglePlayInstant/Editor/BuildTools/AndroidSdk.cs
@@ -1,0 +1,59 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using UnityEditor;
+
+namespace GooglePlayInstant.Editor.BuildTools
+{
+    /// <summary>
+    /// Build tool for finding the Android SDK root path.
+    /// </summary>
+    public class AndroidSdk
+    {
+        /// <summary>
+        /// The ANDROID_HOME environment variable key.
+        /// </summary>
+        public const string AndroidHomeEnvironmentVariableKey = "ANDROID_HOME";
+        private const string AndroidNdkHomeEnvironmentVariableKey = "ANDROID_NDK_HOME";
+        private const string AndroidSdkRootEditorPrefsKey = "AndroidSdkRoot";
+        private const string AndroidNdkRootEditorPrefsKey = "AndroidNdkRoot";
+
+        /// <summary>
+        /// Apply a workaround for Unity versions that fail if the AndroidSdkRoot/AndroidNdkRoot preferences aren't set.
+        /// </summary>
+        public static void ApplyEditorPrefsWorkaround()
+        {
+            // Unlike older versions of Unity, app builds on 2019.2 fail if the SDK/NDK preferences aren't set.
+#if UNITY_2019_2_OR_NEWER
+            var sdkPath = AndroidHomeEnvironmentVariable;
+            if (!string.IsNullOrEmpty(sdkPath))
+            {
+                EditorPrefs.SetString(AndroidSdkRootEditorPrefsKey, sdkPath);
+            }
+
+            var ndkPath = Environment.GetEnvironmentVariable(AndroidNdkHomeEnvironmentVariableKey);
+            if (!string.IsNullOrEmpty(ndkPath))
+            {
+                EditorPrefs.SetString(AndroidNdkRootEditorPrefsKey, ndkPath);
+            }
+#endif
+        }
+
+        private static string AndroidHomeEnvironmentVariable
+        {
+            get { return Environment.GetEnvironmentVariable(AndroidHomeEnvironmentVariableKey); }
+        }
+    }
+}

--- a/GooglePlayInstant/Editor/BuildTools/AndroidSdk.cs.meta
+++ b/GooglePlayInstant/Editor/BuildTools/AndroidSdk.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 408798f1df959420d8fb95911a935f2d
+timeCreated: 1556899571
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/GooglePlayInstant/Editor/CommandLineBuilder.cs
+++ b/GooglePlayInstant/Editor/CommandLineBuilder.cs
@@ -14,6 +14,7 @@
 
 using System;
 using GooglePlayInstant.Editor.AndroidManifest;
+using GooglePlayInstant.Editor.BuildTools;
 using UnityEditor;
 
 namespace GooglePlayInstant.Editor
@@ -30,6 +31,8 @@ namespace GooglePlayInstant.Editor
         /// </summary>
         public static void ConfigureProject(string[] scenesInBuild)
         {
+            AndroidSdk.ApplyEditorPrefsWorkaround();
+
             var requiredPolicies = PlayInstantSettingPolicy.GetRequiredPolicies();
             foreach (var policy in requiredPolicies)
             {


### PR DESCRIPTION
The AndroidSdkRoot Editor Preference must be set on Unity 2019.2 for it to find the Android SDK.