### PR TITLE
Add support for 2019.3

### DIFF
--- a/GooglePlayInstant/Editor/AndroidManifest/PostGenerateGradleProjectAndroidManifestUpdater.cs
+++ b/GooglePlayInstant/Editor/AndroidManifest/PostGenerateGradleProjectAndroidManifestUpdater.cs
@@ -28,6 +28,17 @@ namespace GooglePlayInstant.Editor.AndroidManifest
     public class PostGenerateGradleProjectAndroidManifestUpdater : IAndroidManifestUpdater,
         IPostGenerateGradleAndroidProject
     {
+        // The path to the base manifest changed as part of Unity's "use Unity as a library" feature:
+        // https://blogs.unity3d.com/2019/06/17/add-features-powered-by-unity-to-native-mobile-apps/
+        private const string AndroidManifestRelativePath =
+#if UNITY_2019_3_OR_NEWER
+            // Expected gradle project path: "Temp/gradleOut/unityLibrary"
+            "../launcher/src/main/AndroidManifest.xml";
+#else
+            // Expected gradle project path: "Temp/gradleOut"
+            "src/main/AndroidManifest.xml";
+#endif
+
         public int callbackOrder
         {
             get { return 100; }
@@ -41,7 +52,7 @@ namespace GooglePlayInstant.Editor.AndroidManifest
             }
 
             // Update the final merged AndroidManifest.xml prior to the gradle build.
-            var manifestPath = Path.Combine(path, "src/main/AndroidManifest.xml");
+            var manifestPath = Path.Combine(path, AndroidManifestRelativePath);
             Debug.LogFormat("Updating manifest for Play Instant: {0}", manifestPath);
 
             Uri uri = null;

--- a/GooglePlayInstant/Editor/AppBundlePublisher.cs
+++ b/GooglePlayInstant/Editor/AppBundlePublisher.cs
@@ -15,8 +15,8 @@
 // In the Unity 2017 series the EditorUserBuildSettings.buildAppBundle field was introduced in 2017.4.17.
 // It might seem preferable to modify buildAppBundle using reflection, but the field is extern.
 // Instead check for quite a few versions in the 2017.4.17+ series.
-// NOTE: this supports up to UNITY_2017_4_40 and will have to be extended if additional versions are released.
-#if UNITY_2018_3_OR_NEWER || UNITY_2017_4_17 || UNITY_2017_4_18 || UNITY_2017_4_19 || UNITY_2017_4_20 || UNITY_2017_4_21 || UNITY_2017_4_22 || UNITY_2017_4_23 || UNITY_2017_4_24 || UNITY_2017_4_25 || UNITY_2017_4_26 || UNITY_2017_4_27 || UNITY_2017_4_28 || UNITY_2017_4_29 || UNITY_2017_4_30 || UNITY_2017_4_31 || UNITY_2017_4_32 || UNITY_2017_4_33 || UNITY_2017_4_34 || UNITY_2017_4_35 || UNITY_2017_4_36 || UNITY_2017_4_37 || UNITY_2017_4_38 || UNITY_2017_4_39 || UNITY_2017_4_40
+// NOTE: this supports up to UNITY_2017_4_50 and will have to be extended if additional versions are released.
+#if UNITY_2018_3_OR_NEWER || UNITY_2017_4_17 || UNITY_2017_4_18 || UNITY_2017_4_19 || UNITY_2017_4_20 || UNITY_2017_4_21 || UNITY_2017_4_22 || UNITY_2017_4_23 || UNITY_2017_4_24 || UNITY_2017_4_25 || UNITY_2017_4_26 || UNITY_2017_4_27 || UNITY_2017_4_28 || UNITY_2017_4_29 || UNITY_2017_4_30 || UNITY_2017_4_31 || UNITY_2017_4_32 || UNITY_2017_4_33 || UNITY_2017_4_34 || UNITY_2017_4_35 || UNITY_2017_4_36 || UNITY_2017_4_37 || UNITY_2017_4_38 || UNITY_2017_4_39 || UNITY_2017_4_40 || UNITY_2017_4_41 || UNITY_2017_4_42 || UNITY_2017_4_43 || UNITY_2017_4_44 || UNITY_2017_4_45 || UNITY_2017_4_46 || UNITY_2017_4_47 || UNITY_2017_4_48 || UNITY_2017_4_49 || UNITY_2017_4_50
 #define PLAY_INSTANT_HAS_NATIVE_ANDROID_APP_BUNDLE
 #endif
 

--- a/GooglePlayInstant/Editor/BuildTools.meta
+++ b/GooglePlayInstant/Editor/BuildTools.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: edf7cf7d5f2f842c6a3d7560a19d10ca
+folderAsset: yes
+timeCreated: 1576261825
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/GooglePlayInstant/Editor/CommandLineBuilder.cs
+++ b/GooglePlayInstant/Editor/CommandLineBuilder.cs
@@ -93,9 +93,11 @@ namespace GooglePlayInstant.Editor
 
         private static void SetTargetArchitectures()
         {
+#if UNITY_2019_3_OR_NEWER
+            PlayerSettings.Android.targetArchitectures = AndroidArchitecture.ARMv7;
+#elif UNITY_2018_1_OR_NEWER || UNITY_2017_4_16 || UNITY_2017_4_17 || UNITY_2017_4_18 || UNITY_2017_4_19 || UNITY_2017_4_20 || UNITY_2017_4_21 || UNITY_2017_4_22 || UNITY_2017_4_23 || UNITY_2017_4_24 || UNITY_2017_4_25 || UNITY_2017_4_26 || UNITY_2017_4_27 || UNITY_2017_4_28 || UNITY_2017_4_29 || UNITY_2017_4_30 || UNITY_2017_4_31 || UNITY_2017_4_32 || UNITY_2017_4_33 || UNITY_2017_4_34 || UNITY_2017_4_35 || UNITY_2017_4_36 || UNITY_2017_4_37 || UNITY_2017_4_38 || UNITY_2017_4_39 || UNITY_2017_4_40 || UNITY_2017_4_41 || UNITY_2017_4_42 || UNITY_2017_4_43 || UNITY_2017_4_44 || UNITY_2017_4_45 || UNITY_2017_4_46 || UNITY_2017_4_47 || UNITY_2017_4_48 || UNITY_2017_4_49 || UNITY_2017_4_50
             // Unity 2017.4.16 added support for ARM64. There is no UNITY_2017_4_16_OR_NEWER, so we make a best effort.
-            // NOTE: this supports up to UNITY_2017_4_40 and will have to be extended if more versions are released.
-#if UNITY_2018_1_OR_NEWER || UNITY_2017_4_16 || UNITY_2017_4_17 || UNITY_2017_4_18 || UNITY_2017_4_19 || UNITY_2017_4_20 || UNITY_2017_4_21 || UNITY_2017_4_22 || UNITY_2017_4_23 || UNITY_2017_4_24 || UNITY_2017_4_25 || UNITY_2017_4_26 || UNITY_2017_4_27 || UNITY_2017_4_28 || UNITY_2017_4_29 || UNITY_2017_4_30 || UNITY_2017_4_31 || UNITY_2017_4_32 || UNITY_2017_4_33 || UNITY_2017_4_34 || UNITY_2017_4_35 || UNITY_2017_4_36 || UNITY_2017_4_37 || UNITY_2017_4_38 || UNITY_2017_4_39 || UNITY_2017_4_40
+            // NOTE: this supports up to UNITY_2017_4_50 and will have to be extended if more versions are released.
             PlayerSettings.Android.targetArchitectures = AndroidArchitecture.X86 | AndroidArchitecture.ARMv7;
 #else
             PlayerSettings.Android.targetDevice = AndroidTargetDevice.FAT;

--- a/GooglePlayInstant/Editor/GooglePlayServices/JavaUtilities.cs
+++ b/GooglePlayInstant/Editor/GooglePlayServices/JavaUtilities.cs
@@ -49,7 +49,14 @@ namespace GooglePlayInstant.Editor.GooglePlayServices {
         /// Get the JDK path (JAVA_HOME) configured in the Unity editor.
         /// </summary>
         private static string EditorJavaHome {
-            get { return UnityEditor.EditorPrefs.GetString("JdkPath"); }
+            get
+            {
+#if UNITY_2019_3_OR_NEWER
+                return UnityEditor.Android.AndroidExternalToolsSettings.jdkRootPath;
+#else
+                return UnityEditor.EditorPrefs.GetString("JdkPath");
+#endif
+            }
         }
 
         /// <summary>

--- a/GooglePlayInstant/GooglePlayInstantUtils.cs
+++ b/GooglePlayInstant/GooglePlayInstantUtils.cs
@@ -29,7 +29,7 @@ namespace GooglePlayInstant
         /// <summary>
         /// The version of the Google Play Instant Unity Plugin.
         /// </summary>
-        public const string PluginVersion = "0.10";
+        public const string PluginVersion = "0.11";
 
         /// <summary>
         /// Return true if this is an instant app build, false if an installed app build.


### PR DESCRIPTION
 - Use new AndroidExternalToolsSettings API for Java and SDK paths
 - Handle new location of base AndroidManifest.xml
 - Extend out the number of versions of 2017.4 that we support for 64 bit
 - Add missing BuildTools.meta